### PR TITLE
aco: integer division improvements

### DIFF
--- a/src/amd/compiler/aco_instruction_selection.cpp
+++ b/src/amd/compiler/aco_instruction_selection.cpp
@@ -720,11 +720,11 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
          sub->getDefinition(0) = Definition(dst);
          ctx->block->instructions.emplace_back(std::move(sub));
       } else if (dst.regClass() == s1) {
-         aco_ptr<SOPK_instruction> sopk{create_instruction<SOPK_instruction>(aco_opcode::s_mulk_i32, Format::SOPK, 1, 1)};
-         sopk->getOperand(0) = Operand(get_alu_src(ctx, instr->src[0]));
-         sopk->getDefinition(0) = Definition(dst);
-         sopk->imm = 0xFFFF;
-         ctx->block->instructions.emplace_back(std::move(sopk));
+         aco_ptr<SOP2_instruction> sop2{create_instruction<SOP2_instruction>(aco_opcode::s_mul_i32, Format::SOP2, 2, 1)};
+         sop2->getOperand(1) = Operand((uint32_t) -1);
+         sop2->getOperand(0) = Operand(get_alu_src(ctx, instr->src[0]));
+         sop2->getDefinition(0) = Definition(dst);
+         ctx->block->instructions.emplace_back(std::move(sop2));
       } else {
          fprintf(stderr, "Unimplemented NIR instr bit size: ");
          nir_print_instr(&instr->instr, stderr);

--- a/src/amd/compiler/aco_instruction_selection.cpp
+++ b/src/amd/compiler/aco_instruction_selection.cpp
@@ -2038,6 +2038,49 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
       ctx->block->instructions.emplace_back(std::move(sub));
       break;
    }
+   case nir_op_urcp: {
+      if (dst.regClass() == v1 || dst.regClass() == s1) {
+         Temp src0 = get_alu_src(ctx, instr->src[0]);
+         aco_ptr<Instruction> instr;
+
+         instr.reset(create_instruction<VOP1_instruction>(aco_opcode::v_cvt_f32_u32, Format::VOP1, 1, 1));
+         instr->getOperand(0) = Operand(src0);
+         Temp f_src0 = {ctx->program->allocateId(), v1};
+         instr->getDefinition(0) = Definition(f_src0);
+         ctx->block->instructions.emplace_back(std::move(instr));
+
+         instr.reset(create_instruction<VOP1_instruction>(aco_opcode::v_rcp_iflag_f32, Format::VOP1, 1, 1));
+         instr->getOperand(0) = Operand(f_src0);
+         Temp rcp = {ctx->program->allocateId(), v1};
+         instr->getDefinition(0) = Definition(rcp);
+         ctx->block->instructions.emplace_back(std::move(instr));
+
+         instr.reset(create_instruction<VOP2_instruction>(aco_opcode::v_mul_f32, Format::VOP2, 2, 1));
+         instr->getOperand(0) = Operand((uint32_t) 0x4f800000);
+         instr->getOperand(1) = Operand(rcp);
+         Temp f_dst = {ctx->program->allocateId(), v1};
+         instr->getDefinition(0) = Definition(f_dst);
+         ctx->block->instructions.emplace_back(std::move(instr));
+
+         Temp tmp = dst.regClass() == s1 ? Temp{ctx->program->allocateId(), v1} : dst;
+         instr.reset(create_instruction<VOP1_instruction>(aco_opcode::v_cvt_u32_f32, Format::VOP1, 1, 1));
+         instr->getOperand(0) = Operand(f_dst);
+         instr->getDefinition(0) = Definition(tmp);
+         ctx->block->instructions.emplace_back(std::move(instr));
+
+         if (dst.regClass() == s1) {
+            instr.reset(create_instruction<VOP1_instruction>(aco_opcode::v_readfirstlane_b32, Format::VOP1, 1, 1));
+            instr->getOperand(0) = Operand(tmp);
+            instr->getDefinition(0) = Definition(dst);
+            ctx->block->instructions.emplace_back(std::move(instr));
+         }
+      } else {
+         fprintf(stderr, "Unimplemented NIR instr bit size: ");
+         nir_print_instr(&instr->instr, stderr);
+         fprintf(stderr, "\n");
+      }
+      break;
+   }
    case nir_op_idiv:
    case nir_op_udiv: {
       if (dst.regClass() == v1) {

--- a/src/amd/compiler/aco_instruction_selection.cpp
+++ b/src/amd/compiler/aco_instruction_selection.cpp
@@ -590,43 +590,6 @@ void emit_bcsel(isel_context *ctx, nir_alu_instr *instr, Temp dst)
    }
 }
 
-void emit_udiv(isel_context* ctx, Temp src0, Temp src1, Temp dst)
-{
-   // FIXME: this algorithm is wrong in the general case, but works most of the time.
-   aco_ptr<Instruction> instr;
-
-   instr.reset(create_instruction<VOP1_instruction>(aco_opcode::v_cvt_f32_u32, Format::VOP1, 1, 1));
-   instr->getOperand(0) = Operand(src0);
-   Temp f_src0 = {ctx->program->allocateId(), v1};
-   instr->getDefinition(0) = Definition(f_src0);
-   ctx->block->instructions.emplace_back(std::move(instr));
-
-   instr.reset(create_instruction<VOP1_instruction>(aco_opcode::v_cvt_f32_u32, Format::VOP1, 1, 1));
-   instr->getOperand(0) = Operand(src1);
-   Temp f_src1 = {ctx->program->allocateId(), v1};
-   instr->getDefinition(0) = Definition(f_src1);
-   ctx->block->instructions.emplace_back(std::move(instr));
-
-   instr.reset(create_instruction<VOP1_instruction>(aco_opcode::v_rcp_iflag_f32, Format::VOP1, 1, 1));
-   instr->getOperand(0) = Operand(f_src1);
-   Temp rcp = {ctx->program->allocateId(), v1};
-   instr->getDefinition(0) = Definition(rcp);
-   ctx->block->instructions.emplace_back(std::move(instr));
-
-   instr.reset(create_instruction<VOP2_instruction>(aco_opcode::v_mul_f32, Format::VOP2, 2, 1));
-   instr->getOperand(0) = Operand(f_src0);
-   instr->getOperand(1) = Operand(rcp);
-   Temp f_dst = {ctx->program->allocateId(), v1};
-   instr->getDefinition(0) = Definition(f_dst);
-   ctx->block->instructions.emplace_back(std::move(instr));
-
-   instr.reset(create_instruction<VOP1_instruction>(aco_opcode::v_cvt_u32_f32, Format::VOP1, 1, 1));
-   instr->getOperand(0) = Operand(f_dst);
-   instr->getDefinition(0) = Definition(dst);
-   ctx->block->instructions.emplace_back(std::move(instr));
-
-}
-
 void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
 {
    if (!instr->dest.dest.is_ssa) {
@@ -2078,20 +2041,6 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
          fprintf(stderr, "Unimplemented NIR instr bit size: ");
          nir_print_instr(&instr->instr, stderr);
          fprintf(stderr, "\n");
-      }
-      break;
-   }
-   case nir_op_idiv:
-   case nir_op_udiv: {
-      if (dst.regClass() == v1) {
-         emit_udiv(ctx, get_alu_src(ctx, instr->src[0]), get_alu_src(ctx, instr->src[1]), dst);
-      } else {
-         Temp tmp = {ctx->program->allocateId(), v1};
-         emit_udiv(ctx, get_alu_src(ctx, instr->src[0]), get_alu_src(ctx, instr->src[1]), tmp);
-         aco_ptr<VOP1_instruction> readlane{create_instruction<VOP1_instruction>(aco_opcode::v_readfirstlane_b32, Format::VOP1, 1, 1)};
-         readlane->getOperand(0) = Operand(tmp);
-         readlane->getDefinition(0) = Definition(dst);
-         ctx->block->instructions.emplace_back(std::move(readlane));
       }
       break;
    }

--- a/src/amd/compiler/aco_instruction_selection_setup.cpp
+++ b/src/amd/compiler/aco_instruction_selection_setup.cpp
@@ -939,6 +939,7 @@ setup_isel_context(Program* program, nir_shader *nir,
    nir_copy_prop(nir);
    if (nir_opt_idiv_const(nir, 32))
       nir_lower_bool_to_int32(nir);
+   nir_lower_idiv(nir, true);
    nir_opt_shrink_load(nir);
    nir_opt_cse(nir);
    nir_opt_dce(nir);

--- a/src/broadcom/compiler/vir.c
+++ b/src/broadcom/compiler/vir.c
@@ -625,7 +625,7 @@ v3d_lower_nir_late(struct v3d_compile *c)
 {
         NIR_PASS_V(c->s, v3d_nir_lower_io, c);
         NIR_PASS_V(c->s, v3d_nir_lower_txf_ms, c);
-        NIR_PASS_V(c->s, nir_lower_idiv);
+        NIR_PASS_V(c->s, nir_lower_idiv, false);
 }
 
 static void

--- a/src/compiler/nir/nir.h
+++ b/src/compiler/nir/nir.h
@@ -3048,7 +3048,7 @@ typedef struct nir_lower_tex_options {
 bool nir_lower_tex(nir_shader *shader,
                    const nir_lower_tex_options *options);
 
-bool nir_lower_idiv(nir_shader *shader);
+bool nir_lower_idiv(nir_shader *shader, bool use_urcp);
 
 bool nir_lower_clip_vs(nir_shader *shader, unsigned ucp_enables, bool use_vars);
 bool nir_lower_clip_fs(nir_shader *shader, unsigned ucp_enables);

--- a/src/compiler/nir/nir_lower_idiv.c
+++ b/src/compiler/nir/nir_lower_idiv.c
@@ -27,13 +27,17 @@
 #include "nir.h"
 #include "nir_builder.h"
 
-/* Lowers idiv/udiv/umod
- * Based on NV50LegalizeSSA::handleDIV()
+/* Has two paths
+ * One lowers idiv/udiv/umod and is based on NV50LegalizeSSA::handleDIV()
  *
- * Note that this is probably not enough precision for compute shaders.
- * Perhaps we want a second higher precision (looping) version of this?
- * Or perhaps we assume if you can do compute shaders you can also
- * branch out to a pre-optimized shader library routine..
+ * Note that this path probably does not have not enough precision for
+ * compute shaders. Perhaps we want a second higher precision (looping)
+ * version of this? Or perhaps we assume if you can do compute shaders you
+ * can also branch out to a pre-optimized shader library routine..
+ *
+ * The other path (enabled with use_urcp) requires nir_op_urcp and is
+ * based off of code used by LLVM's AMDGPU target. It should handle 32-bit
+ * idiv/irem/imod/udiv/umod exactly.
  */
 
 static bool
@@ -118,8 +122,104 @@ convert_instr(nir_builder *bld, nir_alu_instr *alu)
    return true;
 }
 
+/* ported from LLVM's AMDGPUTargetLowering::LowerUDIVREM */
+static nir_ssa_def *
+emit_udiv(nir_builder *bld, nir_ssa_def *numer, nir_ssa_def *denom, bool modulo)
+{
+   nir_ssa_def *RCP = nir_urcp(bld, denom);
+   nir_ssa_def *RCP_LO = nir_imul(bld, RCP, denom);
+   nir_ssa_def *RCP_HI = nir_umul_high(bld, RCP, denom);
+   nir_ssa_def *NEG_RCP_LO = nir_ineg(bld, RCP_LO);
+   nir_ssa_def *ABS_RCP_LO = nir_b32csel(bld, RCP_HI, RCP_LO, NEG_RCP_LO);
+   nir_ssa_def *E = nir_umul_high(bld, ABS_RCP_LO, RCP);
+   nir_ssa_def *RCP_A_E = nir_iadd(bld, RCP, E);
+   nir_ssa_def *RCP_S_E = nir_isub(bld, RCP, E);
+   nir_ssa_def *Tmp0 = nir_b32csel(bld, RCP_HI, RCP_S_E, RCP_A_E);
+   nir_ssa_def *Quotient = nir_umul_high(bld, Tmp0, numer);
+   nir_ssa_def *Num_S_Remainder = nir_imul(bld, Quotient, denom);
+   nir_ssa_def *Remainder = nir_isub(bld, numer, Num_S_Remainder);
+   nir_ssa_def *Remainder_GE_Den = nir_uge32(bld, Remainder, denom);
+   nir_ssa_def *Remainder_GE_Zero = nir_uge32(bld, numer, Num_S_Remainder);
+   nir_ssa_def *Tmp1 = nir_iand(bld, Remainder_GE_Den, Remainder_GE_Zero);
+
+   if (modulo) {
+      nir_ssa_def *Remainder_S_Den = nir_isub(bld, Remainder, denom);
+      nir_ssa_def *Remainder_A_Den = nir_iadd(bld, Remainder, denom);
+      nir_ssa_def *Rem = nir_b32csel(bld, Tmp1, Remainder_S_Den, Remainder);
+      return nir_b32csel(bld, Remainder_GE_Zero, Rem, Remainder_A_Den);
+   } else {
+      nir_ssa_def *Quotient_A_One = nir_iadd(bld, Quotient, nir_imm_int(bld, 1));
+      nir_ssa_def *Quotient_S_One = nir_isub(bld, Quotient, nir_imm_int(bld, 1));
+      nir_ssa_def *Div = nir_b32csel(bld, Tmp1, Quotient_A_One, Quotient);
+      return nir_b32csel(bld, Remainder_GE_Zero, Div, Quotient_S_One);
+   }
+}
+
+/* ported from LLVM's AMDGPUTargetLowering::LowerSDIVREM */
+static nir_ssa_def *
+emit_idiv(nir_builder *bld, nir_ssa_def *numer, nir_ssa_def *denom, nir_op op)
+{
+   nir_ssa_def *LHSign = nir_ilt32(bld, numer, nir_imm_int(bld, 0));
+   nir_ssa_def *RHSign = nir_ilt32(bld, denom, nir_imm_int(bld, 0));
+
+   nir_ssa_def *LHS = nir_iadd(bld, numer, LHSign);
+   nir_ssa_def *RHS = nir_iadd(bld, denom, RHSign);
+   LHS = nir_ixor(bld, LHS, LHSign);
+   RHS = nir_ixor(bld, RHS, RHSign);
+
+   if (op == nir_op_idiv) {
+      nir_ssa_def *DSign = nir_ixor(bld, LHSign, RHSign);
+      nir_ssa_def *res = emit_udiv(bld, LHS, RHS, false);
+      res = nir_ixor(bld, res, DSign);
+      return nir_isub(bld, res, DSign);
+   } else {
+      nir_ssa_def *res = emit_udiv(bld, LHS, RHS, true);
+      res = nir_ixor(bld, res, LHSign);
+      res = nir_isub(bld, res, LHSign);
+      if (op == nir_op_imod) {
+         nir_ssa_def *cond = nir_ieq32(bld, res, nir_imm_int(bld, 0));
+         cond = nir_ior(bld, nir_iand(bld, LHSign, RHSign), cond);
+         res = nir_b32csel(bld, cond, res, nir_iadd(bld, res, denom));
+      }
+      return res;
+   }
+}
+
 static bool
-convert_impl(nir_function_impl *impl)
+convert_instr_urcp(nir_builder *bld, nir_alu_instr *alu)
+{
+   nir_op op = alu->op;
+
+   if ((op != nir_op_idiv) &&
+       (op != nir_op_imod) &&
+       (op != nir_op_irem) &&
+       (op != nir_op_udiv) &&
+       (op != nir_op_umod))
+      return false;
+
+   if (alu->dest.dest.ssa.bit_size != 32)
+      return false;
+
+   bld->cursor = nir_before_instr(&alu->instr);
+
+   nir_ssa_def *numer = nir_ssa_for_alu_src(bld, alu, 0);
+   nir_ssa_def *denom = nir_ssa_for_alu_src(bld, alu, 1);
+
+   nir_ssa_def *res = NULL;
+
+   if (op == nir_op_udiv || op == nir_op_umod)
+      res = emit_udiv(bld, numer, denom, op == nir_op_umod);
+   else
+      res = emit_idiv(bld, numer, denom, op);
+
+   assert(alu->dest.dest.is_ssa);
+   nir_ssa_def_rewrite_uses(&alu->dest.dest.ssa, nir_src_for_ssa(res));
+
+   return true;
+}
+
+static bool
+convert_impl(nir_function_impl *impl, bool use_urcp)
 {
    nir_builder b;
    nir_builder_init(&b, impl);
@@ -127,7 +227,9 @@ convert_impl(nir_function_impl *impl)
 
    nir_foreach_block(block, impl) {
       nir_foreach_instr_safe(instr, block) {
-         if (instr->type == nir_instr_type_alu)
+         if (instr->type == nir_instr_type_alu && use_urcp)
+            progress |= convert_instr_urcp(&b, nir_instr_as_alu(instr));
+         else if (instr->type == nir_instr_type_alu)
             progress |= convert_instr(&b, nir_instr_as_alu(instr));
       }
    }
@@ -139,13 +241,13 @@ convert_impl(nir_function_impl *impl)
 }
 
 bool
-nir_lower_idiv(nir_shader *shader)
+nir_lower_idiv(nir_shader *shader, bool use_urcp)
 {
    bool progress = false;
 
    nir_foreach_function(function, shader) {
       if (function->impl)
-         progress |= convert_impl(function->impl);
+         progress |= convert_impl(function->impl, use_urcp);
    }
 
    return progress;

--- a/src/compiler/nir/nir_opcodes.py
+++ b/src/compiler/nir/nir_opcodes.py
@@ -194,6 +194,7 @@ unop("fsat", tfloat, ("bit_size == 64 ? " +
                       "((src0 > 1.0) ? 1.0 : ((src0 <= 0.0) ? 0.0 : src0)) : " +
                       "((src0 > 1.0f) ? 1.0f : ((src0 <= 0.0f) ? 0.0f : src0))"))
 unop("frcp", tfloat, "bit_size == 64 ? 1.0 / src0 : 1.0f / src0")
+unop("urcp", tuint32, "(uint32_t)(1 / (float)src0 * 4294967296.0)")
 unop("frsq", tfloat, "bit_size == 64 ? 1.0 / sqrt(src0) : 1.0f / sqrtf(src0)")
 unop("fsqrt", tfloat, "bit_size == 64 ? sqrt(src0) : sqrtf(src0)")
 unop("fexp2", tfloat, "exp2f(src0)")

--- a/src/freedreno/ir3/ir3_nir.c
+++ b/src/freedreno/ir3/ir3_nir.c
@@ -191,7 +191,7 @@ ir3_optimize_nir(struct ir3_shader *shader, nir_shader *s,
 	/* do idiv lowering after first opt loop to give a chance for
 	 * divide by immed power-of-two to be caught first:
 	 */
-	if (OPT(s, nir_lower_idiv))
+	if (OPT(s, nir_lower_idiv, false))
 		ir3_optimize_loop(s);
 
 	OPT_V(s, nir_remove_dead_variables, nir_var_local);

--- a/src/gallium/drivers/vc4/vc4_program.c
+++ b/src/gallium/drivers/vc4/vc4_program.c
@@ -2381,7 +2381,7 @@ vc4_shader_ntq(struct vc4_context *vc4, enum qstage stage,
 
         NIR_PASS_V(c->s, vc4_nir_lower_io, c);
         NIR_PASS_V(c->s, vc4_nir_lower_txf_ms, c);
-        NIR_PASS_V(c->s, nir_lower_idiv);
+        NIR_PASS_V(c->s, nir_lower_idiv, false);
 
         vc4_optimize_nir(c->s);
 


### PR DESCRIPTION
This pull request implements `nir_op_umod`, `nir_op_imod` and `nir_op_irem` and replaces the incorrect implementations of `nir_op_idiv` and `nir_op_udiv`. It also fixes a bug with sgpr `nir_op_ineg` and implements `nir_op_uadd_sat` (sometimes created by `nir_opt_idiv_const`).

This was initially going to use Algorithm 2 from [N-Bit Unsigned Division Via N-Bit Multiply-Add ](http://www.acsel-lab.com/arithmetic/arith17/papers/ARITH17_Robison.pdf), but I could not get it working for some divisions using large operands (such as `4294967295 / 3` or `4108096384 / 586870912`). So the code used is ported from LLVM.