### PR TITLE
amd/compiler: set driver location for shared variables

### DIFF
--- a/src/amd/compiler/aco_instruction_selection_setup.cpp
+++ b/src/amd/compiler/aco_instruction_selection_setup.cpp
@@ -895,6 +895,7 @@ setup_variables(isel_context *ctx, nir_shader *nir)
       unsigned lds_size_bytes = 0;
       nir_foreach_variable(variable, &nir->shared)
       {
+         variable->data.driver_location = lds_size_bytes;
          lds_size_bytes += total_shared_var_size(variable->type);
       }
       const unsigned lds_allocation_size_unit = 4 * 64;


### PR DESCRIPTION
This is needed so `nir_lower_io` can handle compute shaders with multiple shared variables such as the ones found in Shadow of the Tomb Raider.

This fixes various graphical artifacts with the main menu when compute shaders are compiled with ACO.