### PR TITLE
aco: one bit booleans and fixes

### DIFF
--- a/src/amd/compiler/aco_instruction_selection.cpp
+++ b/src/amd/compiler/aco_instruction_selection.cpp
@@ -245,6 +245,86 @@ void expand_vector(isel_context* ctx, Temp vec_src, Temp dst, unsigned num_compo
    ctx->allocated_vec.emplace(dst.id(), elems);
 }
 
+/* this can't be relied upon to be correct */
+bool is_scc_tmp_clobbered(isel_context *ctx, Temp val)
+{
+   for (int i = ctx->block->instructions.size() - 1; i >= 0; --i) {
+      Instruction *instr = ctx->block->instructions[i].get();
+      /* checking operands has almost no effect on code quality in practice */
+      if (!instr->isSALU())
+         continue;
+      for (uint32_t j = 0; j < instr->definitionCount(); j++) {
+         Definition& def = instr->getDefinition(j);
+         if (def.isTemp() && def.regClass() == b) {
+            return def.tempId() != val.id();
+         }
+         if (def.isFixed() && def.physReg() == scc) {
+            return true;
+         }
+      }
+   }
+   return true;
+}
+
+Temp as_divergent_bool(isel_context *ctx, Temp val, bool vcc_hint)
+{
+   if (val.regClass() == b) {
+      Temp new_val{ctx->program->allocateId(), s2};
+
+      auto it32 = ctx->allocated_bool32.find(val.id());
+      if (it32 != ctx->allocated_bool32.end() && is_scc_tmp_clobbered(ctx, val)) {
+         /* avoid spilling SCC */
+         Temp bool32{it32->second, s1};
+
+         aco_ptr<Instruction> vec{create_instruction<Instruction>(aco_opcode::p_create_vector, Format::PSEUDO, 2, 1)};
+         vec->getOperand(0) = Operand(bool32);
+         vec->getOperand(1) = Operand(bool32);
+         vec->getDefinition(0) = Definition(new_val);
+         if (vcc_hint)
+            vec->getDefinition(0).setHint(vcc);
+         ctx->block->instructions.emplace_back(std::move(vec));
+      } else {
+         aco_ptr<Instruction> cselect{create_instruction<SOP2_instruction>(aco_opcode::s_cselect_b64, Format::SOP2, 3, 1)};
+         cselect->getOperand(0) = Operand((uint32_t) -1);
+         cselect->getOperand(1) = Operand((uint32_t) 0);
+         cselect->getOperand(2) = Operand(val);
+         cselect->getOperand(2).setFixed(scc);
+         cselect->getDefinition(0) = Definition(new_val);
+         if (vcc_hint)
+            cselect->getDefinition(0).setHint(vcc);
+         ctx->block->instructions.emplace_back(std::move(cselect));
+      }
+      return new_val;
+   }
+   assert(val.regClass() == s2);
+   return val;
+}
+
+Temp as_uniform_bool32(isel_context *ctx, Temp val, bool update)
+{
+   if (val.regClass() == b) {
+      auto it = ctx->allocated_bool32.find(val.id());
+      if (it != ctx->allocated_bool32.end())
+         return Temp{it->second, s1};
+
+      aco_ptr<Instruction> cselect{create_instruction<SOP2_instruction>(aco_opcode::s_cselect_b32, Format::SOP2, 3, 1)};
+      cselect->getOperand(0) = Operand((uint32_t) -1);
+      cselect->getOperand(1) = Operand((uint32_t) 0);
+      cselect->getOperand(2) = Operand(val);
+      cselect->getOperand(2).setFixed(scc);
+      Temp new_val = Temp{ctx->program->allocateId(), s1};
+      cselect->getDefinition(0) = Definition(new_val);
+      ctx->block->instructions.emplace_back(std::move(cselect));
+
+      if (update)
+         ctx->allocated_bool32.emplace(val.id(), new_val.id());
+
+      return new_val;
+   }
+   assert(val.regClass() == s1);
+   return val;
+}
+
 Temp get_alu_src(struct isel_context *ctx, nir_alu_src src)
 {
    if (src.src.ssa->num_components == 1 && src.swizzle[0] == 0)
@@ -380,35 +460,64 @@ void emit_vopc_instruction(isel_context *ctx, nir_alu_instr *instr, aco_opcode o
    ctx->block->instructions.emplace_back(std::move(vopc));
 }
 
-void emit_vopc_instruction_output32(isel_context *ctx, nir_alu_instr *instr, aco_opcode op, Temp dst)
+void emit_comparison(isel_context *ctx, nir_alu_instr *instr, aco_opcode scalar_op, aco_opcode vec_op, Temp dst)
 {
-   Temp tmp{ctx->program->allocateId(), s2};
+   if (dst.regClass() == s2) {
+      emit_vopc_instruction(ctx, instr, vec_op, dst);
+   } else if (dst.regClass() == b) {
+      Temp src0 = get_alu_src(ctx, instr->src[0]);
+      Temp src1 = get_alu_src(ctx, instr->src[1]);
 
-   emit_vopc_instruction(ctx, instr, op, tmp);
+      if (scalar_op == aco_opcode::num_opcodes && src1.regClass() != v1)
+         src0 = as_vgpr(ctx, src0);
 
-   if (dst.regClass() == v1) {
-      aco_ptr<Instruction> bcsel{create_instruction<VOP3A_instruction>(aco_opcode::v_cndmask_b32, static_cast<Format>((int)Format::VOP2 | (int)Format::VOP3A), 3, 1)};
-      bcsel->getOperand(0) = Operand((uint32_t) 0);
-      bcsel->getOperand(1) = Operand((uint32_t) -1);
-      bcsel->getOperand(2) = Operand{tmp};
-      bcsel->getDefinition(0) = Definition(dst);
-      ctx->block->instructions.emplace_back(std::move(bcsel));
+      if (src0.regClass() == v1 || src1.regClass() == v1) {
+         Temp dst_tmp = {ctx->program->allocateId(), s2};
+         emit_vopc_instruction(ctx, instr, vec_op, dst_tmp);
+         aco_ptr<Instruction> cmp{create_instruction<SOPC_instruction>(aco_opcode::s_cmp_lg_u64, Format::SOPC, 2, 1)};
+         cmp->getOperand(0) = Operand(dst_tmp);
+         cmp->getOperand(1) = Operand((uint32_t) 0);
+         cmp->getDefinition(0) = Definition(dst);
+         cmp->getDefinition(0).setFixed(scc);
+         ctx->block->instructions.emplace_back(std::move(cmp));
+         ctx->allocated_bool32.emplace(dst.id(), emit_extract_vector(ctx, dst_tmp, 0, s1).id());
+      } else {
+         assert(scalar_op != aco_opcode::num_opcodes);
+         aco_ptr<SOPC_instruction> cmp{create_instruction<SOPC_instruction>(scalar_op, Format::SOPC, 2, 1)};
+         cmp->getOperand(0) = Operand(src0);
+         cmp->getOperand(1) = Operand(src1);
+         cmp->getDefinition(0) = Definition(dst);
+         cmp->getDefinition(0).setFixed(scc);
+         ctx->block->instructions.emplace_back(std::move(cmp));
+         /* best to have this conversion done earlier because of SCC live-range splitting */
+         as_uniform_bool32(ctx, dst, true);
+      }
    } else {
-      Temp scc_tmp{ctx->program->allocateId(), b};
-      aco_ptr<Instruction> cmp{create_instruction<SOPC_instruction>(aco_opcode::s_cmp_lg_u64, Format::SOPC, 2, 1)};
-      cmp->getOperand(0) = Operand{tmp};
-      cmp->getOperand(1) = Operand((uint32_t) 0);
-      cmp->getDefinition(0) = Definition{scc_tmp};
-      cmp->getDefinition(0).setFixed(scc);
-      ctx->block->instructions.emplace_back(std::move(cmp));
+      assert(false);
+   }
+}
 
-      aco_ptr<Instruction> cselect{create_instruction<SOP2_instruction>(aco_opcode::s_cselect_b32, Format::SOP2, 3, 1)};
-      cselect->getOperand(0) = Operand((uint32_t) -1);
-      cselect->getOperand(1) = Operand((uint32_t) 0);
-      cselect->getOperand(2) = Operand{scc_tmp};
-      cselect->getOperand(2).setFixed(scc);
-      cselect->getDefinition(0) = Definition(dst);
-      ctx->block->instructions.emplace_back(std::move(cselect));
+void emit_boolean_logic(isel_context *ctx, nir_alu_instr *instr, aco_opcode op32, aco_opcode op64, Temp dst)
+{
+   if (dst.regClass() == s2) {
+      aco_ptr<SOP2_instruction> sop2{create_instruction<SOP2_instruction>(op64, Format::SOP2, 2, 2)};
+      sop2->getOperand(0) = Operand(as_divergent_bool(ctx, get_alu_src(ctx, instr->src[0]), false));
+      sop2->getOperand(1) = Operand(as_divergent_bool(ctx, get_alu_src(ctx, instr->src[1]), false));
+      sop2->getDefinition(0) = Definition(dst);
+      sop2->getDefinition(1) = Definition(ctx->program->allocateId(), scc, b);
+      ctx->block->instructions.emplace_back(std::move(sop2));
+   } else {
+      assert(dst.regClass() == b);
+      aco_ptr<SOP2_instruction> sop2{create_instruction<SOP2_instruction>(op32, Format::SOP2, 2, 2)};
+      sop2->getOperand(0) = Operand(as_uniform_bool32(ctx, get_alu_src(ctx, instr->src[0]), false));
+      sop2->getOperand(1) = Operand(as_uniform_bool32(ctx, get_alu_src(ctx, instr->src[1]), false));
+      Temp dst32{ctx->program->allocateId(), s1};
+      sop2->getDefinition(0) = Definition(dst32);
+      sop2->getDefinition(1) = Definition(dst);
+      sop2->getDefinition(1).setFixed(scc);
+      ctx->block->instructions.emplace_back(std::move(sop2));
+
+      ctx->allocated_bool32.emplace(dst.id(), dst32.id());
    }
 }
 
@@ -463,117 +572,88 @@ void emit_quad_swizzle(isel_context *ctx, Temp src, Temp dst,
 
 void emit_bcsel(isel_context *ctx, nir_alu_instr *instr, Temp dst)
 {
-   Temp cond32 = get_alu_src(ctx, instr->src[0]);
+   Temp cond = get_alu_src(ctx, instr->src[0]);
    Temp then = get_alu_src(ctx, instr->src[1]);
    Temp els = get_alu_src(ctx, instr->src[2]);
 
    if (dst.type() == vgpr) {
-      Temp cond;
-      if (cond32.type() == vgpr) {
-         cond = extract_divergent_cond32(ctx, cond32);
+      cond = as_divergent_bool(ctx, cond, true);
+
+      aco_ptr<Instruction> bcsel;
+      if (dst.size() == 1) {
+         then = as_vgpr(ctx, then);
+         els = as_vgpr(ctx, els);
+
+         bcsel.reset(create_instruction<VOP2_instruction>(aco_opcode::v_cndmask_b32, Format::VOP2, 3, 1));
+         bcsel->getOperand(0) = Operand{els};
+         bcsel->getOperand(1) = Operand{then};
+         bcsel->getOperand(2) = Operand{cond};
+         bcsel->getDefinition(0) = Definition(dst);
+         ctx->block->instructions.emplace_back(std::move(bcsel));
+      } else if (dst.size() == 2) {
+         emit_split_vector(ctx, then, 2);
+         emit_split_vector(ctx, els, 2);
+
+         bcsel.reset(create_instruction<VOP2_instruction>(aco_opcode::v_cndmask_b32, Format::VOP2, 3, 1));
+         bcsel->getOperand(0) = Operand{emit_extract_vector(ctx, els, 0, v1)};
+         bcsel->getOperand(1) = Operand{emit_extract_vector(ctx, then, 0, v1)};
+         bcsel->getOperand(2) = Operand{cond};
+         Temp dst0 = {ctx->program->allocateId(), v1};
+         bcsel->getDefinition(0) = Definition(dst0);
+         ctx->block->instructions.emplace_back(std::move(bcsel));
+
+         bcsel.reset(create_instruction<VOP2_instruction>(aco_opcode::v_cndmask_b32, Format::VOP2, 3, 1));
+         bcsel->getOperand(0) = Operand{emit_extract_vector(ctx, els, 1, v1)};
+         bcsel->getOperand(1) = Operand{emit_extract_vector(ctx, then, 1, v1)};
+         bcsel->getOperand(2) = Operand{cond};
+         Temp dst1 = {ctx->program->allocateId(), v1};
+         bcsel->getDefinition(0) = Definition(dst1);
+         ctx->block->instructions.emplace_back(std::move(bcsel));
+
+         bcsel.reset(create_instruction<Instruction>(aco_opcode::p_create_vector, Format::PSEUDO, 2, 1));
+         bcsel->getOperand(0) = Operand(dst0);
+         bcsel->getOperand(1) = Operand(dst1);
+         bcsel->getDefinition(0) = Definition(dst);
+         ctx->block->instructions.emplace_back(std::move(bcsel));
       } else {
-         Temp scc_tmp = extract_uniform_cond32(ctx, cond32);
-         aco_ptr<Instruction> cselect{create_instruction<SOP2_instruction>(aco_opcode::s_cselect_b64, Format::SOP2, 3, 1)};
-         cselect->getOperand(0) = Operand((uint32_t) -1);
-         cselect->getOperand(1) = Operand((uint32_t) 0);
-         cselect->getOperand(2) = Operand{scc_tmp};
-         cselect->getOperand(2).setFixed(scc);
-         cond = Temp{ctx->program->allocateId(), s2};
-         cselect->getDefinition(0) = Definition(cond);
-         cselect->getDefinition(0).setHint(vcc);
-         ctx->block->instructions.emplace_back(std::move(cselect));
+         fprintf(stderr, "Unimplemented NIR instr bit size: ");
+         nir_print_instr(&instr->instr, stderr);
+         fprintf(stderr, "\n");
       }
-      if (dst.type() == vgpr) {
-         aco_ptr<Instruction> bcsel;
-         if (dst.size() == 1) {
-            then = as_vgpr(ctx, then);
-            els = as_vgpr(ctx, els);
+   } else if (dst.regClass() == s2 && instr->dest.dest.ssa.bit_size == 1) { /* divergent boolean bcsel */
+      cond = as_divergent_bool(ctx, cond, false);
+      then = as_divergent_bool(ctx, then, false);
+      els = as_divergent_bool(ctx, els, false);
 
-            bcsel.reset(create_instruction<VOP2_instruction>(aco_opcode::v_cndmask_b32, Format::VOP2, 3, 1));
-            bcsel->getOperand(0) = Operand{els};
-            bcsel->getOperand(1) = Operand{then};
-            bcsel->getOperand(2) = Operand{cond};
-            bcsel->getDefinition(0) = Definition(dst);
-            ctx->block->instructions.emplace_back(std::move(bcsel));
-         } else if (dst.regClass() == v2) {
-            emit_split_vector(ctx, then, 2);
-            emit_split_vector(ctx, els, 2);
+      /* this implements bcsel on bools: dst = s0 ? s1 : s2
+       * are going to be: dst = (s0 & s1) | (~s0 & s2) */
+      assert(then.regClass() == s2 && els.regClass() == s2);
 
-            bcsel.reset(create_instruction<VOP2_instruction>(aco_opcode::v_cndmask_b32, Format::VOP2, 3, 1));
-            bcsel->getOperand(0) = Operand{emit_extract_vector(ctx, els, 0, v1)};
-            bcsel->getOperand(1) = Operand{emit_extract_vector(ctx, then, 0, v1)};
-            bcsel->getOperand(2) = Operand{cond};
-            Temp dst0 = {ctx->program->allocateId(), v1};
-            bcsel->getDefinition(0) = Definition(dst0);
-            ctx->block->instructions.emplace_back(std::move(bcsel));
+      aco_ptr<SOP2_instruction> sop2;
+      sop2.reset(create_instruction<SOP2_instruction>(aco_opcode::s_and_b64, Format::SOP2, 2, 2));
+      sop2->getOperand(0) = Operand(cond);
+      sop2->getOperand(1) = Operand(then);
+      then = Temp(ctx->program->allocateId(), s2);
+      sop2->getDefinition(0) = Definition(then);
+      sop2->getDefinition(1) = Definition(ctx->program->allocateId(), scc, b);
+      ctx->block->instructions.emplace_back(std::move(sop2));
 
-            bcsel.reset(create_instruction<VOP2_instruction>(aco_opcode::v_cndmask_b32, Format::VOP2, 3, 1));
-            bcsel->getOperand(0) = Operand{emit_extract_vector(ctx, els, 1, v1)};
-            bcsel->getOperand(1) = Operand{emit_extract_vector(ctx, then, 1, v1)};
-            bcsel->getOperand(2) = Operand{cond};
-            Temp dst1 = {ctx->program->allocateId(), v1};
-            bcsel->getDefinition(0) = Definition(dst1);
-            ctx->block->instructions.emplace_back(std::move(bcsel));
+      sop2.reset(create_instruction<SOP2_instruction>(aco_opcode::s_andn2_b64, Format::SOP2, 2, 2));
+      sop2->getOperand(0) = Operand(els);
+      sop2->getOperand(1) = Operand(cond);
+      els = Temp(ctx->program->allocateId(), s2);
+      sop2->getDefinition(0) = Definition(els);
+      sop2->getDefinition(1) = Definition(ctx->program->allocateId(), scc, b);
+      ctx->block->instructions.emplace_back(std::move(sop2));
 
-            bcsel.reset(create_instruction<Instruction>(aco_opcode::p_create_vector, Format::PSEUDO, 2, 1));
-            bcsel->getOperand(0) = Operand(dst0);
-            bcsel->getOperand(1) = Operand(dst1);
-            bcsel->getDefinition(0) = Definition(dst);
-            ctx->block->instructions.emplace_back(std::move(bcsel));
-         } else {
-            fprintf(stderr, "Unimplemented NIR instr bit size: ");
-            nir_print_instr(&instr->instr, stderr);
-            fprintf(stderr, "\n");
-         }
-      } else { /* dst.type() == sgpr */
-         unreachable("Are 1-bit Bools enabled... ?");
-
-         /* this implements bcsel on bools: dst = s0 ? s1 : s2
-          * are going to be: dst = (s0 & s1) | (~s0 & s2) */
-         assert(cond.regClass() == s2 && then.regClass() == s2 && els.regClass() == s2);
-
-         aco_ptr<SOP2_instruction> sop2;
-         sop2.reset(create_instruction<SOP2_instruction>(aco_opcode::s_and_b64, Format::SOP2, 2, 2));
-         sop2->getOperand(0) = Operand(cond);
-         sop2->getOperand(1) = Operand(then);
-         then = Temp(ctx->program->allocateId(), s2);
-         sop2->getDefinition(0) = Definition(then);
-         sop2->getDefinition(1) = Definition(ctx->program->allocateId(), scc, b);
-         ctx->block->instructions.emplace_back(std::move(sop2));
-
-         sop2.reset(create_instruction<SOP2_instruction>(aco_opcode::s_andn2_b64, Format::SOP2, 2, 2));
-         sop2->getOperand(0) = Operand(els);
-         sop2->getOperand(1) = Operand(cond);
-         els = Temp(ctx->program->allocateId(), s2);
-         sop2->getDefinition(0) = Definition(els);
-         sop2->getDefinition(1) = Definition(ctx->program->allocateId(), scc, b);
-         ctx->block->instructions.emplace_back(std::move(sop2));
-
-         sop2.reset(create_instruction<SOP2_instruction>(aco_opcode::s_or_b64, Format::SOP2, 2, 2));
-         sop2->getOperand(0) = Operand(then);
-         sop2->getOperand(1) = Operand(els);
-         then = Temp(ctx->program->allocateId(), s2);
-         sop2->getDefinition(0) = Definition(dst);
-         sop2->getDefinition(1) = Definition(ctx->program->allocateId(), scc, b);
-         ctx->block->instructions.emplace_back(std::move(sop2));
-      }
-   } else { /* condition is uniform */
-      Temp cond;
-      if (cond32.type() == vgpr) {
-         cond = extract_divergent_cond32(ctx, cond32);
-      } else {
-         cond = extract_uniform_cond32(ctx, cond32);
-      }
-      if (cond.regClass() == s2) {
-         cond = emit_extract_vector(ctx, cond, 0, s1);
-         aco_ptr<SOPK_instruction> sopk{create_instruction<SOPK_instruction>(aco_opcode::s_cmpk_lg_u32, Format::SOPK, 1, 1)};
-         sopk->getOperand(0) = Operand(cond);
-         sopk->imm = 0;
-         cond = {ctx->program->allocateId(), b};
-         sopk->getDefinition(0) = Definition(cond);
-         sopk->getDefinition(0).setFixed(scc);
-         ctx->block->instructions.emplace_back(std::move(sopk));
-      }
+      sop2.reset(create_instruction<SOP2_instruction>(aco_opcode::s_or_b64, Format::SOP2, 2, 2));
+      sop2->getOperand(0) = Operand(then);
+      sop2->getOperand(1) = Operand(els);
+      then = Temp(ctx->program->allocateId(), s2);
+      sop2->getDefinition(0) = Definition(dst);
+      sop2->getDefinition(1) = Definition(ctx->program->allocateId(), scc, b);
+      ctx->block->instructions.emplace_back(std::move(sop2));
+   } else if (dst.type() == sgpr) { /* condition is uniform */
       assert(cond.regClass() == b);
       if (dst.regClass() == s1 || dst.regClass() == s2) {
          assert((then.regClass() == s1 || then.regClass() == s2) && els.regClass() == then.regClass());
@@ -589,6 +669,26 @@ void emit_bcsel(isel_context *ctx, nir_alu_instr *instr, Temp dst)
          nir_print_instr(&instr->instr, stderr);
          fprintf(stderr, "\n");
       }
+   } else { /* uniform boolean bcsel */
+      assert(dst.regClass() == b && cond.regClass() == b);
+
+      aco_ptr<Instruction> cselect{create_instruction<SOP2_instruction>(aco_opcode::s_cselect_b32, Format::SOP2, 3, 1)};
+      cselect->getOperand(0) = Operand(as_uniform_bool32(ctx, then, false));
+      cselect->getOperand(1) = Operand(as_uniform_bool32(ctx, els, false));
+      cselect->getOperand(2) = Operand(cond);
+      cselect->getOperand(2).setFixed(scc);
+      Temp tmp = {ctx->program->allocateId(), s1};
+      cselect->getDefinition(0) = Definition(tmp);
+      ctx->block->instructions.emplace_back(std::move(cselect));
+
+      ctx->allocated_bool32.emplace(dst.id(), tmp.id());
+
+      aco_ptr<Instruction> cmp{create_instruction<SOPC_instruction>(aco_opcode::s_cmp_lg_u32, Format::SOPC, 2, 1)};
+      cmp->getOperand(0) = Operand(tmp);
+      cmp->getOperand(1) = Operand((uint32_t) 0);
+      cmp->getDefinition(0) = Definition(dst);
+      cmp->getDefinition(0).setFixed(scc);
+      ctx->block->instructions.emplace_back(std::move(cmp));
    }
 }
 
@@ -626,12 +726,20 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
             mov.reset(create_instruction<SOP1_instruction>(aco_opcode::s_mov_b32, Format::SOP1, 1, 1));
       } else if (dst.regClass() == v1) {
          mov.reset(create_instruction<VOP1_instruction>(aco_opcode::v_mov_b32, Format::VOP1, 1, 1));
+      } else if (dst.regClass() == s2) {
+         mov.reset(create_instruction<SOP1_instruction>(aco_opcode::s_mov_b64, Format::SOP1, 1, 1));
+      } else if (dst.regClass() == b) {
+         mov.reset(create_instruction<SOPC_instruction>(aco_opcode::s_cmp_lg_u32, Format::SOPC, 1, 1));
+         mov->getOperand(1) = Operand((uint32_t) 0);
       } else {
          fprintf(stderr, "Unimplemented NIR instr bit size: ");
          nir_print_instr(&instr->instr, stderr);
          fprintf(stderr, "\n");
       }
-      mov->getOperand(0) = Operand(src);
+      if (dst.regClass() == b)
+         mov->getOperand(0) = Operand(as_uniform_bool32(ctx, src, false));
+      else
+         mov->getOperand(0) = Operand(src);
       mov->getDefinition(0) = Definition(dst);
       ctx->block->instructions.emplace_back(std::move(mov));
       break;
@@ -653,7 +761,24 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
       break;
    }
    case nir_op_inot: {
-      if (dst.regClass() == v1) {
+      if (instr->dest.dest.ssa.bit_size == 1) {
+         if (dst.regClass() == s2) {
+            aco_ptr<SOP2_instruction> sop2{create_instruction<SOP2_instruction>(aco_opcode::s_not_b64, Format::SOP1, 1, 2)};
+            sop2->getOperand(0) = Operand(as_divergent_bool(ctx, get_alu_src(ctx, instr->src[0]), false));
+            sop2->getDefinition(0) = Definition(dst);
+            sop2->getDefinition(1) = Definition(ctx->program->allocateId(), scc, b);
+            ctx->block->instructions.emplace_back(std::move(sop2));
+         } else {
+            assert(dst.regClass() == b);
+            aco_ptr<SOP2_instruction> sop2{create_instruction<SOP2_instruction>(aco_opcode::s_not_b32, Format::SOP1, 1, 2)};
+            sop2->getOperand(0) = Operand(as_uniform_bool32(ctx, get_alu_src(ctx, instr->src[0]), false));
+            sop2->getDefinition(0) = Definition{ctx->program->allocateId(), s1};
+            sop2->getDefinition(1) = Definition(dst);
+            sop2->getDefinition(1).setFixed(scc);
+            ctx->block->instructions.emplace_back(std::move(sop2));
+            ctx->allocated_bool32.emplace(dst.id(), sop2->getDefinition(0).tempId());
+         }
+      } else if (dst.regClass() == v1) {
          emit_vop1_instruction(ctx, instr, aco_opcode::v_not_b32, dst);
       } else if (dst.type() == sgpr) {
          aco_opcode opcode = dst.size() == 1 ? aco_opcode::s_not_b32 : aco_opcode::s_not_b64;
@@ -775,7 +900,9 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
       break;
    }
    case nir_op_ior: {
-      if (dst.regClass() == v1) {
+      if (instr->dest.dest.ssa.bit_size == 1) {
+         emit_boolean_logic(ctx, instr, aco_opcode::s_or_b32, aco_opcode::s_or_b64, dst);
+      } else if (dst.regClass() == v1) {
          emit_vop2_instruction(ctx, instr, aco_opcode::v_or_b32, dst, true);
       } else if (dst.regClass() == s1) {
          emit_sop2_instruction(ctx, instr, aco_opcode::s_or_b32, dst, true);
@@ -789,7 +916,9 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
       break;
    }
    case nir_op_iand: {
-      if (dst.regClass() == v1) {
+      if (instr->dest.dest.ssa.bit_size == 1) {
+         emit_boolean_logic(ctx, instr, aco_opcode::s_and_b32, aco_opcode::s_and_b64, dst);
+      } else if (dst.regClass() == v1) {
          emit_vop2_instruction(ctx, instr, aco_opcode::v_and_b32, dst, true);
       } else if (dst.regClass() == s1) {
          emit_sop2_instruction(ctx, instr, aco_opcode::s_and_b32, dst, true);
@@ -803,7 +932,9 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
       break;
    }
    case nir_op_ixor: {
-      if (dst.regClass() == v1) {
+      if (instr->dest.dest.ssa.bit_size == 1) {
+         emit_boolean_logic(ctx, instr, aco_opcode::s_xor_b32, aco_opcode::s_xor_b64, dst);
+      } else if (dst.regClass() == v1) {
          emit_vop2_instruction(ctx, instr, aco_opcode::v_xor_b32, dst, true);
       } else if (dst.regClass() == s1) {
          emit_sop2_instruction(ctx, instr, aco_opcode::s_xor_b32, dst, true);
@@ -1209,7 +1340,7 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
       }
       break;
    }
-   case nir_op_b32csel: {
+   case nir_op_bcsel: {
       emit_bcsel(ctx, instr, dst);
       break;
    }
@@ -1465,12 +1596,15 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
       break;
    }
    case nir_op_b2f32: {
-      Temp cond32 = get_alu_src(ctx, instr->src[0]);
-      aco_ptr<VOP3A_instruction> cndmask{create_instruction<VOP3A_instruction>(aco_opcode::v_and_b32, (Format) ((int) Format::VOP3A | (int) Format::VOP2), 2, 1)};
-      cndmask->getOperand(0) = Operand(cond32);
-      cndmask->getOperand(1) = Operand((uint32_t) 0x3f800000); /* 1.0 */
-      cndmask->getDefinition(0) = Definition(dst);
-      ctx->block->instructions.emplace_back(std::move(cndmask));
+      Temp src = get_alu_src(ctx, instr->src[0]);
+      assert(dst.regClass() == v1);
+      Format format = (Format) ((uint32_t) Format::VOP2 | (uint32_t) Format::VOP3A);
+      aco_ptr<Instruction> bcsel{create_instruction<VOP3A_instruction>(aco_opcode::v_cndmask_b32, format, 3, 1)};
+      bcsel->getOperand(0) = Operand((uint32_t) 0);
+      bcsel->getOperand(1) = Operand((uint32_t) 0x3f800000);
+      bcsel->getOperand(2) = Operand(as_divergent_bool(ctx, src, true));
+      bcsel->getDefinition(0) = Definition(dst);
+      ctx->block->instructions.emplace_back(std::move(bcsel));
       break;
    }
    case nir_op_u2u32: {
@@ -1508,30 +1642,45 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
    case nir_op_b2i32: {
       Temp src = get_alu_src(ctx, instr->src[0]);
       if (dst.regClass() == s1) {
-         assert(src.regClass() == s1);
-         Temp scc_tmp = extract_uniform_cond32(ctx, src);
+         assert(src.regClass() == b);
          aco_ptr<Instruction> cselect{create_instruction<SOP2_instruction>(aco_opcode::s_cselect_b32, Format::SOP2, 3, 1)};
          cselect->getOperand(0) = Operand((uint32_t) 1);
          cselect->getOperand(1) = Operand((uint32_t) 0);
-         cselect->getOperand(2) = Operand{scc_tmp};
+         cselect->getOperand(2) = Operand(src);
          cselect->getOperand(2).setFixed(scc);
          cselect->getDefinition(0) = Definition(dst);
          ctx->block->instructions.emplace_back(std::move(cselect));
-      } else if (dst.regClass() == v1) {
-         assert(src.regClass() == v1);
-         Temp tmp = extract_divergent_cond32(ctx, src);
+      } else {
+         assert(dst.regClass() == v1 && src.regClass() == s2);
          Format format = (Format) ((uint32_t) Format::VOP2 | (uint32_t) Format::VOP3A);
          aco_ptr<Instruction> bcsel{create_instruction<VOP3A_instruction>(aco_opcode::v_cndmask_b32, format, 3, 1)};
          bcsel->getOperand(0) = Operand((uint32_t) 0);
          bcsel->getOperand(1) = Operand((uint32_t) 1);
-         bcsel->getOperand(2) = Operand{tmp};
+         bcsel->getOperand(2) = Operand(src);
          bcsel->getDefinition(0) = Definition(dst);
          ctx->block->instructions.emplace_back(std::move(bcsel));
-
+      }
+      break;
+   }
+   case nir_op_i2b1: {
+      Temp src = get_alu_src(ctx, instr->src[0]);
+      if (dst.regClass() == s2) {
+         assert(src.regClass() == v1);
+         aco_ptr<Instruction> cmp{create_instruction<VOPC_instruction>(aco_opcode::v_cmp_lg_u32, Format::VOPC, 2, 1)};
+         cmp->getOperand(0) = Operand((uint32_t) 0);
+         cmp->getOperand(1) = Operand(src);
+         cmp->getDefinition(0) = Definition(dst);
+         cmp->getDefinition(0).setHint(vcc);
+         ctx->block->instructions.emplace_back(std::move(cmp));
       } else {
-         fprintf(stderr, "Unimplemented NIR instr bit size: ");
-         nir_print_instr(&instr->instr, stderr);
-         fprintf(stderr, "\n");
+         assert(src.regClass() == s1 && dst.regClass() == b);
+         aco_ptr<SOPK_instruction> sop{create_instruction<SOPK_instruction>(aco_opcode::s_cmp_lg_u32, Format::SOPC, 2, 1)};
+         sop->getOperand(0) = Operand((uint32_t) 0);
+         sop->getOperand(1) = Operand(src);
+         sop->getDefinition(0) = Definition(dst);
+         sop->getDefinition(0).setFixed(scc);
+         ctx->block->instructions.emplace_back(std::move(sop));
+         as_uniform_bool32(ctx, dst, true);
       }
       break;
    }
@@ -1851,140 +2000,44 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
       }
       break;
    }
-   case nir_op_feq32: {
-      if (instr->src[0].src.ssa->bit_size == 32) {
-         emit_vopc_instruction_output32(ctx, instr, aco_opcode::v_cmp_eq_f32, dst);
-      } else {
-         fprintf(stderr, "Unimplemented NIR instr bit size: ");
-         nir_print_instr(&instr->instr, stderr);
-         fprintf(stderr, "\n");
-      }
+   case nir_op_flt: {
+      emit_comparison(ctx, instr, aco_opcode::num_opcodes, aco_opcode::v_cmp_lt_f32, dst);
       break;
    }
-   case nir_op_fne32: {
-      if (instr->src[0].src.ssa->bit_size == 32) {
-         emit_vopc_instruction_output32(ctx, instr, aco_opcode::v_cmp_lg_f32, dst);
-      } else {
-         fprintf(stderr, "Unimplemented NIR instr bit size: ");
-         nir_print_instr(&instr->instr, stderr);
-         fprintf(stderr, "\n");
-      }
+   case nir_op_fge: {
+      emit_comparison(ctx, instr, aco_opcode::num_opcodes, aco_opcode::v_cmp_ge_f32, dst);
       break;
    }
-   case nir_op_flt32: {
-      if (instr->src[0].src.ssa->bit_size == 32) {
-         emit_vopc_instruction_output32(ctx, instr, aco_opcode::v_cmp_lt_f32, dst);
-      } else {
-         fprintf(stderr, "Unimplemented NIR instr bit size: ");
-         nir_print_instr(&instr->instr, stderr);
-         fprintf(stderr, "\n");
-      }
+   case nir_op_feq: {
+      emit_comparison(ctx, instr, aco_opcode::num_opcodes, aco_opcode::v_cmp_eq_f32, dst);
       break;
    }
-   case nir_op_fge32: {
-      if (instr->src[0].src.ssa->bit_size == 32) {
-         emit_vopc_instruction_output32(ctx, instr, aco_opcode::v_cmp_ge_f32, dst);
-      } else {
-         fprintf(stderr, "Unimplemented NIR instr bit size: ");
-         nir_print_instr(&instr->instr, stderr);
-         fprintf(stderr, "\n");
-      }
+   case nir_op_fne: {
+      emit_comparison(ctx, instr, aco_opcode::num_opcodes, aco_opcode::v_cmp_lg_f32, dst);
       break;
    }
-   case nir_op_ieq32: {
-      if (dst.regClass() == v1) {
-         emit_vopc_instruction_output32(ctx, instr, aco_opcode::v_cmp_eq_i32, dst);
-      } else if (dst.regClass() == s1) {
-         Temp src0 = get_alu_src(ctx, instr->src[0]);
-         Temp src1 = get_alu_src(ctx, instr->src[1]);
-         if (src0.regClass() == v1 || src1.regClass() == v1) {
-            Temp dst_tmp = {ctx->program->allocateId(), s2};
-            emit_vopc_instruction(ctx, instr, aco_opcode::v_cmp_eq_i32, dst_tmp);
-            emit_extract_vector(ctx, dst_tmp, 0, dst);
-         } else {
-            emit_sopc_instruction_output32(ctx, instr, aco_opcode::s_cmp_eq_i32, dst);
-         }
-      }
+   case nir_op_ilt: {
+      emit_comparison(ctx, instr, aco_opcode::s_cmp_lt_i32, aco_opcode::v_cmp_lt_i32, dst);
       break;
    }
-   case nir_op_ine32: {
-      if (dst.regClass() == v1) {
-         emit_vopc_instruction_output32(ctx, instr, aco_opcode::v_cmp_lg_i32, dst);
-      } else if (dst.regClass() == s1) {
-         Temp src0 = get_alu_src(ctx, instr->src[0]);
-         Temp src1 = get_alu_src(ctx, instr->src[1]);
-         if (src0.regClass() == v1 || src1.regClass() == v1) {
-            Temp dst_tmp = {ctx->program->allocateId(), s2};
-            emit_vopc_instruction(ctx, instr, aco_opcode::v_cmp_lg_i32, dst_tmp);
-            emit_extract_vector(ctx, dst_tmp, 0, dst);
-         } else {
-            emit_sopc_instruction_output32(ctx, instr, aco_opcode::s_cmp_lg_i32, dst);
-         }
-      }
+   case nir_op_ige: {
+      emit_comparison(ctx, instr, aco_opcode::s_cmp_ge_i32, aco_opcode::v_cmp_ge_i32, dst);
       break;
    }
-   case nir_op_ilt32: {
-      if (dst.regClass() == v1) {
-         emit_vopc_instruction_output32(ctx, instr, aco_opcode::v_cmp_lt_i32, dst);
-      } else if (dst.regClass() == s1) {
-         Temp src0 = get_alu_src(ctx, instr->src[0]);
-         Temp src1 = get_alu_src(ctx, instr->src[1]);
-         if (src0.regClass() == v1 || src1.regClass() == v1) {
-            Temp dst_tmp = {ctx->program->allocateId(), s2};
-            emit_vopc_instruction(ctx, instr, aco_opcode::v_cmp_lt_i32, dst_tmp);
-            emit_extract_vector(ctx, dst_tmp, 0, dst);
-         } else {
-            emit_sopc_instruction_output32(ctx, instr, aco_opcode::s_cmp_lt_i32, dst);
-         }
-      }
+   case nir_op_ieq: {
+      emit_comparison(ctx, instr, aco_opcode::s_cmp_eq_i32, aco_opcode::v_cmp_eq_i32, dst);
       break;
    }
-   case nir_op_ige32: {
-      if (dst.regClass() == v1) {
-         emit_vopc_instruction_output32(ctx, instr, aco_opcode::v_cmp_ge_i32, dst);
-      } else if (dst.regClass() == s1) {
-         Temp src0 = get_alu_src(ctx, instr->src[0]);
-         Temp src1 = get_alu_src(ctx, instr->src[1]);
-         if (src0.regClass() == v1 || src1.regClass() == v1) {
-            Temp dst_tmp = {ctx->program->allocateId(), s2};
-            emit_vopc_instruction(ctx, instr, aco_opcode::v_cmp_ge_i32, dst_tmp);
-            emit_extract_vector(ctx, dst_tmp, 0, dst);
-         } else {
-            emit_sopc_instruction_output32(ctx, instr, aco_opcode::s_cmp_ge_i32, dst);
-         }
-      }
+   case nir_op_ine: {
+      emit_comparison(ctx, instr, aco_opcode::s_cmp_lg_i32, aco_opcode::v_cmp_lg_i32, dst);
       break;
    }
-   case nir_op_ult32: {
-      if (dst.regClass() == v1) {
-         emit_vopc_instruction_output32(ctx, instr, aco_opcode::v_cmp_lt_u32, dst);
-      } else if (dst.regClass() == s1) {
-         Temp src0 = get_alu_src(ctx, instr->src[0]);
-         Temp src1 = get_alu_src(ctx, instr->src[1]);
-         if (src0.regClass() == v1 || src1.regClass() == v1) {
-            Temp dst_tmp = {ctx->program->allocateId(), s2};
-            emit_vopc_instruction(ctx, instr, aco_opcode::v_cmp_lt_u32, dst_tmp);
-            emit_extract_vector(ctx, dst_tmp, 0, dst);
-         } else {
-            emit_sopc_instruction_output32(ctx, instr, aco_opcode::s_cmp_lt_u32, dst);
-         }
-      }
+   case nir_op_ult: {
+      emit_comparison(ctx, instr, aco_opcode::s_cmp_lt_u32, aco_opcode::v_cmp_lt_u32, dst);
       break;
    }
-   case nir_op_uge32: {
-      if (dst.regClass() == v1) {
-         emit_vopc_instruction_output32(ctx, instr, aco_opcode::v_cmp_ge_u32, dst);
-      } else if (dst.regClass() == s1) {
-         Temp src0 = get_alu_src(ctx, instr->src[0]);
-         Temp src1 = get_alu_src(ctx, instr->src[1]);
-         if (src0.regClass() == v1 || src1.regClass() == v1) {
-            Temp dst_tmp = {ctx->program->allocateId(), s2};
-            emit_vopc_instruction(ctx, instr, aco_opcode::v_cmp_ge_u32, dst_tmp);
-            emit_extract_vector(ctx, dst_tmp, 0, dst);
-         } else {
-            emit_sopc_instruction_output32(ctx, instr, aco_opcode::s_cmp_ge_u32, dst);
-         }
-      }
+   case nir_op_uge: {
+      emit_comparison(ctx, instr, aco_opcode::s_cmp_ge_u32, aco_opcode::v_cmp_ge_u32, dst);
       break;
    }
    case nir_op_fddx:
@@ -2071,11 +2124,24 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
 
 void visit_load_const(isel_context *ctx, nir_load_const_instr *instr)
 {
+   Temp dst = get_ssa_temp(ctx, &instr->def);
+
+   if (instr->def.bit_size == 1) {
+      aco_ptr<Instruction> not_b32(create_instruction<SOP1_instruction>(aco_opcode::s_not_b32, Format::SOP1, 1, 2));
+      not_b32->getOperand(0) = Operand((uint32_t) (instr->value.u32[0] ? 0 : 0xffffffff));
+      Temp bool32{ctx->program->allocateId(), s1};
+      not_b32->getDefinition(0) = Definition(bool32);
+      not_b32->getDefinition(1) = Definition(dst);
+      not_b32->getDefinition(1).setFixed(scc);
+      ctx->block->instructions.emplace_back(std::move(not_b32));
+      ctx->allocated_bool32.emplace(dst.id(), bool32.id());
+      return;
+   }
+
    // TODO: we really want to have the resulting type as this would allow for 64bit literals
    // which get truncated the lsb if double and msb if int
    // for now, we only use s_mov_b64 with 64bit inline constants
    assert(instr->def.num_components == 1 && "Vector load_const should be lowered to scalar.");
-   Temp dst = get_ssa_temp(ctx, &instr->def);
    assert(dst.type() == sgpr);
 
    if (dst.size() == 1)
@@ -2617,24 +2683,10 @@ void visit_discard_if(isel_context *ctx, nir_intrinsic_instr *instr)
     * s_endpgm
     * Label
     */
-   Temp cond32 = get_ssa_temp(ctx, instr->src[0].ssa);
-   Temp cond;
-
-   if (cond32.regClass() == s1) {
-      cond = cond32;
-   } else {
-      cond = Temp{ctx->program->allocateId(), s2};
-
-      aco_ptr<Instruction> cmp{create_instruction<VOPC_instruction>(aco_opcode::v_cmp_lg_u32, Format::VOPC, 2, 1)};
-      cmp->getOperand(0) = Operand((uint32_t) 0);
-      cmp->getOperand(1) = Operand{cond32};
-      cmp->getDefinition(0) = Definition{cond};
-      cmp->getDefinition(0).setHint(vcc);
-      ctx->block->instructions.emplace_back(std::move(cmp));
-   }
-
    aco_ptr<Instruction> discard{create_instruction<Instruction>(aco_opcode::p_discard_if, Format::PSEUDO, 1, 1)};
-   discard->getOperand(0) = Operand(cond);
+   discard->getOperand(0) = Operand(get_ssa_temp(ctx, instr->src[0].ssa));
+   if (discard->getOperand(0).regClass() == b)
+      discard->getOperand(0).setFixed(scc);
    discard->getDefinition(0) = Definition{ctx->program->allocateId(), b};
    discard->getDefinition(0).setFixed(scc);
    ctx->block->instructions.emplace_back(std::move(discard));
@@ -3890,7 +3942,12 @@ void visit_intrinsic(isel_context *ctx, nir_intrinsic_instr *instr)
       break;
    }
    case nir_intrinsic_load_front_face: {
-      emit_v_mov(ctx, ctx->fs_inputs[fs_input::front_face], get_ssa_temp(ctx, &instr->dest.ssa));
+      aco_ptr<Instruction> cmp{create_instruction<VOPC_instruction>(aco_opcode::v_cmp_lg_u32, Format::VOPC, 2, 1)};
+      cmp->getOperand(0) = Operand((uint32_t) 0);
+      cmp->getOperand(1) = Operand(ctx->fs_inputs[fs_input::front_face]);
+      cmp->getDefinition(0) = Definition(get_ssa_temp(ctx, &instr->dest.ssa));
+      cmp->getDefinition(0).setHint(vcc);
+      ctx->block->instructions.emplace_back(std::move(cmp));
       break;
    }
    case nir_intrinsic_load_interpolated_input:
@@ -4769,7 +4826,11 @@ void visit_phi(isel_context *ctx, nir_phi_instr *instr)
    aco_ptr<Instruction> phi;
    unsigned num_src = exec_list_length(&instr->srcs);
    Temp dst = get_ssa_temp(ctx, &instr->dest.ssa);
+
    aco_opcode opcode = ctx->divergent_vals[instr->dest.ssa.index] ? aco_opcode::p_phi : aco_opcode::p_linear_phi;
+   if (instr->dest.ssa.bit_size == 1 && opcode == aco_opcode::p_phi && num_src == 1)
+      opcode = aco_opcode::p_linear_phi; /* just a linear phi will do and will avoid expensive lowering */
+
    phi.reset(create_instruction<Instruction>(opcode, Format::PSEUDO, num_src, 1));
    std::map<unsigned, nir_ssa_def*> phi_src;
    nir_foreach_phi_src(src, instr)
@@ -4809,15 +4870,26 @@ void visit_undef(isel_context *ctx, nir_ssa_undef_instr *instr)
    Temp dst = get_ssa_temp(ctx, &instr->def);
    aco_ptr<Instruction> undef;
 
-   if (dst.size() == 1) {
-      undef.reset(create_instruction<SOP1_instruction>(aco_opcode::s_mov_b32, Format::SOP1, 1, 1));
+   if (instr->def.bit_size == 1) {
+      undef.reset(create_instruction<SOP1_instruction>(aco_opcode::s_not_b32, Format::SOP1, 1, 2));
+      undef->getOperand(0) = Operand();
+      Temp bool32{ctx->program->allocateId(), s1};
+      undef->getDefinition(0) = Definition(bool32);
+      undef->getDefinition(1) = Definition(dst);
+      undef->getDefinition(1).setFixed(scc);
+      ctx->block->instructions.emplace_back(std::move(undef));
+      ctx->allocated_bool32.emplace(dst.id(), bool32.id());
    } else {
-      undef.reset(create_instruction<Instruction>(aco_opcode::p_create_vector, Format::PSEUDO, dst.size(), 1));
+      if (dst.size() == 1) {
+         undef.reset(create_instruction<SOP1_instruction>(aco_opcode::s_mov_b32, Format::SOP1, 1, 1));
+      } else {
+         undef.reset(create_instruction<Instruction>(aco_opcode::p_create_vector, Format::PSEUDO, dst.size(), 1));
+      }
+      for (unsigned i = 0; i < dst.size(); i++)
+         undef->getOperand(i) = Operand();
+      undef->getDefinition(0) = Definition(dst);
+      ctx->block->instructions.emplace_back(std::move(undef));
    }
-   for (unsigned i = 0; i < dst.size(); i++)
-      undef->getOperand(i) = Operand();
-   undef->getDefinition(0) = Definition(dst);
-   ctx->block->instructions.emplace_back(std::move(undef));
 }
 
 static void add_logical_edge(Block *pred, Block *succ)
@@ -5112,10 +5184,10 @@ static void visit_loop(isel_context *ctx, nir_loop *loop)
 
 static void visit_if(isel_context *ctx, nir_if *if_stmt)
 {
-   Temp cond32 = get_ssa_temp(ctx, if_stmt->condition.ssa);
+   Temp cond = get_ssa_temp(ctx, if_stmt->condition.ssa);
    aco_ptr<Pseudo_branch_instruction> branch;
 
-   if (cond32.type() == RegType::sgpr) { /* uniform condition */
+   if (cond.regClass() == b) { /* uniform condition */
       /**
        * Uniform conditionals are represented in the following way*) :
        *
@@ -5142,8 +5214,6 @@ static void visit_if(isel_context *ctx, nir_if *if_stmt)
       Block* parent_if_merge_block = ctx->cf_info.parent_if.merge_block;
       ctx->cf_info.parent_if.merge_block = BB_endif;
 
-      /** emit conditional statement */
-      Temp cond = extract_uniform_cond32(ctx, cond32);
       append_logical_end(BB_if);
 
       /* emit branch */
@@ -5262,8 +5332,6 @@ static void visit_if(isel_context *ctx, nir_if *if_stmt)
       Block* BB_endif = new Block();
       BB_endif->loop_nest_depth = ctx->cf_info.loop_nest_depth;
 
-      /** emit conditional statement */
-      Temp cond = extract_divergent_cond32(ctx, cond32);
       append_logical_end(BB_if);
 
       /* create the exec mask for then branch */

--- a/src/amd/compiler/aco_instruction_selection.cpp
+++ b/src/amd/compiler/aco_instruction_selection.cpp
@@ -712,20 +712,20 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
    case nir_op_inot: {
       if (instr->dest.dest.ssa.bit_size == 1) {
          if (dst.regClass() == s2) {
-            aco_ptr<SOP2_instruction> sop2{create_instruction<SOP2_instruction>(aco_opcode::s_not_b64, Format::SOP1, 1, 2)};
-            sop2->getOperand(0) = Operand(as_divergent_bool(ctx, get_alu_src(ctx, instr->src[0]), false));
-            sop2->getDefinition(0) = Definition(dst);
-            sop2->getDefinition(1) = Definition(ctx->program->allocateId(), scc, b);
-            ctx->block->instructions.emplace_back(std::move(sop2));
+            aco_ptr<SOP1_instruction> sop1{create_instruction<SOP1_instruction>(aco_opcode::s_not_b64, Format::SOP1, 1, 2)};
+            sop1->getOperand(0) = Operand(as_divergent_bool(ctx, get_alu_src(ctx, instr->src[0]), false));
+            sop1->getDefinition(0) = Definition(dst);
+            sop1->getDefinition(1) = Definition(ctx->program->allocateId(), scc, b);
+            ctx->block->instructions.emplace_back(std::move(sop1));
          } else {
             assert(dst.regClass() == b);
-            aco_ptr<SOP2_instruction> sop2{create_instruction<SOP2_instruction>(aco_opcode::s_not_b32, Format::SOP1, 1, 2)};
-            sop2->getOperand(0) = Operand(as_uniform_bool32(ctx, get_alu_src(ctx, instr->src[0]), false));
-            sop2->getDefinition(0) = Definition{ctx->program->allocateId(), s1};
-            sop2->getDefinition(1) = Definition(dst);
-            sop2->getDefinition(1).setFixed(scc);
-            ctx->block->instructions.emplace_back(std::move(sop2));
-            ctx->allocated_bool32.emplace(dst.id(), sop2->getDefinition(0).tempId());
+            aco_ptr<SOP1_instruction> sop1{create_instruction<SOP1_instruction>(aco_opcode::s_not_b32, Format::SOP1, 1, 2)};
+            sop1->getOperand(0) = Operand(as_uniform_bool32(ctx, get_alu_src(ctx, instr->src[0]), false));
+            sop1->getDefinition(0) = Definition{ctx->program->allocateId(), s1};
+            sop1->getDefinition(1) = Definition(dst);
+            sop1->getDefinition(1).setFixed(scc);
+            ctx->block->instructions.emplace_back(std::move(sop1));
+            ctx->allocated_bool32.emplace(dst.id(), sop1->getDefinition(0).tempId());
          }
       } else if (dst.regClass() == v1) {
          emit_vop1_instruction(ctx, instr, aco_opcode::v_not_b32, dst);

--- a/src/amd/compiler/aco_instruction_selection_setup.cpp
+++ b/src/amd/compiler/aco_instruction_selection_setup.cpp
@@ -961,10 +961,9 @@ setup_isel_context(Program* program, nir_shader *nir,
    nir_lower_io(nir, (nir_variable_mode)(nir_var_shader_in | nir_var_shader_out), type_size, (nir_lower_io_options)0);
    nir_lower_io(nir, nir_var_shared, shared_var_size, (nir_lower_io_options)0);
    nir_copy_prop(nir);
-   bool lower_bools = nir_opt_idiv_const(nir, 32);
-   lower_bools = nir_lower_idiv(nir, true) || lower_bools;
-   if (lower_bools)
-      nir_lower_bool_to_int32(nir);
+   nir_opt_idiv_const(nir, 32);
+   nir_lower_idiv(nir, true);
+   nir_lower_bool_to_int32(nir);
    nir_opt_shrink_load(nir);
    nir_opt_cse(nir);
    nir_opt_dce(nir);

--- a/src/amd/compiler/aco_interface.cpp
+++ b/src/amd/compiler/aco_interface.cpp
@@ -53,6 +53,12 @@ void aco_compile_shader(struct nir_shader *shader, struct ac_shader_config* conf
       aco_print_program(program.get(), stderr);
    }
    aco::validate(program.get(), stderr);
+
+   /* Boolean phi lowering */
+   aco::lower_bool_phis(program.get());
+   //std::cerr << "After Boolean Phi Lowering:\n";
+   //aco_print_program(program.get(), stderr);
+
    aco::dominator_tree(program.get());
 
    /* Optimization */

--- a/src/amd/compiler/aco_ir.h
+++ b/src/amd/compiler/aco_ir.h
@@ -832,6 +832,7 @@ std::unique_ptr<Program> select_program(struct nir_shader *nir,
                                         struct radv_shader_variant_info *info,
                                         struct radv_nir_compiler_options *options);
 
+void lower_bool_phis(Program* program);
 template<bool condition>
 live live_var_analysis(Program* program,
                        const struct radv_nir_compiler_options *options);

--- a/src/amd/compiler/aco_lower_bool_phis.cpp
+++ b/src/amd/compiler/aco_lower_bool_phis.cpp
@@ -1,0 +1,273 @@
+/*
+ * Copyright © 2018 Valve Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * Authors:
+ *    Rhys Perry (pendingchaos02@gmail.com)
+ *
+ */
+
+#include <map>
+#include <utility>
+
+#include "aco_ir.h"
+
+
+namespace aco {
+
+struct phi_use {
+   Block *block;
+   unsigned phi_def;
+
+   bool operator<(const phi_use& other) const {
+      return std::make_tuple(block, phi_def) <
+             std::make_tuple(other.block, other.phi_def);
+   }
+};
+
+struct ssa_state {
+   std::map<Block *, unsigned> latest;
+   std::map<unsigned, std::map<phi_use, uint64_t>> phis;
+};
+
+Operand get_ssa(Program *program, Block *block, ssa_state *state)
+{
+   Temp res;
+   while (true) {
+      auto pos = state->latest.find(block);
+      if (pos != state->latest.end())
+         return Operand({pos->second, s2});
+
+      size_t pred = block->linear_predecessors.size();
+      if (pred == 0) {
+         return Operand();
+      } else if (pred == 1) {
+         block = block->linear_predecessors[0];
+         continue;
+      } else {
+         unsigned res = program->allocateId();
+         state->latest[block] = res;
+
+         aco_ptr<Instruction> phi{create_instruction<Instruction>(aco_opcode::p_linear_phi, Format::PSEUDO, pred, 1)};
+         for (unsigned i = 0; i < pred; i++) {
+            phi->getOperand(i) = get_ssa(program, block->linear_predecessors[i], state);
+            if (phi->getOperand(i).isTemp()) {
+               assert(i < 64);
+               state->phis[phi->getOperand(i).tempId()][(phi_use){block, res}] |= (uint64_t)1 << i;
+            }
+         }
+         phi->getDefinition(0) = Definition(Temp{res, s2});
+         block->instructions.emplace(block->instructions.begin(), std::move(phi));
+
+         return Operand({res, s2});
+      }
+   }
+}
+
+void update_phi(Program *program, ssa_state *state, Block *block, unsigned phi_def, uint64_t operand_mask) {
+   for (auto& phi : block->instructions) {
+      if (phi->opcode != aco_opcode::p_phi && phi->opcode != aco_opcode::p_linear_phi)
+         break;
+      if (phi->opcode != aco_opcode::p_linear_phi)
+         continue;
+      if (phi->getDefinition(0).tempId() != phi_def)
+         continue;
+      assert(ffsll(operand_mask) <= phi->operandCount());
+
+      uint64_t operands = operand_mask;
+      while (operands) {
+         unsigned operand = u_bit_scan64(&operands);
+         Operand new_operand = get_ssa(program, block->linear_predecessors[operand], state);
+         phi->getOperand(operand) = new_operand;
+         if (!new_operand.isUndefined())
+            state->phis[new_operand.tempId()][(phi_use){block, phi_def}] |= (uint64_t)1 << operand;
+      }
+      return;
+   }
+   assert(false);
+}
+
+Temp write_ssa(Program *program, Block *block, ssa_state *state, unsigned previous) {
+   unsigned id = program->allocateId();
+   state->latest[block] = id;
+
+   /* update phis */
+   if (previous) {
+      std::map<phi_use, uint64_t> phis;
+      phis.swap(state->phis[previous]);
+      for (auto& phi : phis)
+         update_phi(program, state, phi.first.block, phi.first.phi_def, phi.second);
+   }
+
+   return {id, s2};
+}
+
+void insert_before_branch(Block *block, aco_ptr<Instruction> instr)
+{
+   int end = block->instructions.size() - 1;
+   if (block->instructions[end]->format == Format::PSEUDO_BRANCH)
+      block->instructions.emplace(std::prev(block->instructions.end()), std::move(instr));
+   else
+      block->instructions.emplace_back(std::move(instr));
+}
+
+void insert_before_logical_end(Block *block, aco_ptr<Instruction> instr)
+{
+   for (int i = block->instructions.size() - 1; i >= 0; --i) {
+      if (block->instructions[i]->opcode == aco_opcode::p_logical_end) {
+         block->instructions.emplace(std::next(block->instructions.begin(), i), std::move(instr));
+         return;
+      }
+   }
+   insert_before_branch(block, std::move(instr));
+}
+
+aco_ptr<Instruction> lower_divergent_bool_phi(Program *program, Block *block, aco_ptr<Instruction>& phi)
+{
+   ssa_state state;
+   for (unsigned i = 0; i < phi->operandCount(); i++) {
+      Block *pred = block->logical_predecessors[i];
+
+      assert(phi->getOperand(i).isTemp());
+      Temp phi_src = phi->getOperand(i).getTemp();
+      if (phi_src.regClass() == b) {
+         aco_ptr<Instruction> cselect{create_instruction<SOP2_instruction>(aco_opcode::s_cselect_b64, Format::SOP2, 3, 1)};
+         cselect->getOperand(0) = Operand((uint32_t) -1);
+         cselect->getOperand(1) = Operand((uint32_t) 0);
+         cselect->getOperand(2) = Operand(phi_src);
+         cselect->getOperand(2).setFixed(scc);
+         phi_src = {program->allocateId(), s2};
+         cselect->getDefinition(0) = Definition(phi_src);
+         insert_before_logical_end(pred, std::move(cselect));
+      }
+
+      Operand cur = get_ssa(program, pred, &state);
+      Temp new_cur = write_ssa(program, pred, &state, cur.tempId());
+
+      if (cur.isUndefined()) {
+         aco_ptr<Instruction> merge{create_instruction<SOP1_instruction>(aco_opcode::s_mov_b64, Format::SOP1, 1, 1)};
+         merge->getOperand(0) = Operand(phi_src);
+         merge->getDefinition(0) = Definition(new_cur);
+         insert_before_logical_end(pred, std::move(merge));
+      } else {
+         aco_ptr<Instruction> merge{create_instruction<SOP2_instruction>(aco_opcode::s_andn2_b64, Format::SOP2, 2, 2)};
+         merge->getOperand(0) = cur;
+         merge->getOperand(1) = Operand(exec, s2);
+         Temp tmp1{program->allocateId(), s2};
+         merge->getDefinition(0) = Definition(tmp1);
+         merge->getDefinition(1) = Definition(program->allocateId(), scc, b);
+         insert_before_logical_end(pred, std::move(merge));
+
+         merge.reset(create_instruction<SOP2_instruction>(aco_opcode::s_and_b64, Format::SOP2, 2, 2));
+         merge->getOperand(0) = Operand(phi_src);
+         merge->getOperand(1) = Operand(exec, s2);
+         Temp tmp2{program->allocateId(), s2};
+         merge->getDefinition(0) = Definition(tmp2);
+         merge->getDefinition(1) = Definition(program->allocateId(), scc, b);
+         insert_before_logical_end(pred, std::move(merge));
+
+         merge.reset(create_instruction<SOP2_instruction>(aco_opcode::s_or_b64, Format::SOP2, 2, 2));
+         merge->getOperand(0) = Operand(tmp1);
+         merge->getOperand(1) = Operand(tmp2);
+         merge->getDefinition(0) = Definition(new_cur);
+         merge->getDefinition(1) = Definition(program->allocateId(), scc, b);
+         insert_before_logical_end(pred, std::move(merge));
+      }
+   }
+
+   aco_ptr<Instruction> copy{create_instruction<SOP1_instruction>(aco_opcode::s_mov_b64, Format::SOP1, 1, 1)};
+   copy->getOperand(0) = Operand(get_ssa(program, block, &state));
+   copy->getDefinition(0) = phi->getDefinition(0);
+   return copy;
+}
+
+aco_ptr<Instruction> lower_uniform_bool_phi(Program *program, Block *block, aco_ptr<Instruction>& phi)
+{
+   /* TODO: it is possible to implement these without the conversions in some circumstances */
+   for (unsigned i = 0; i < phi->operandCount(); i++) {
+      Block *pred = block->linear_predecessors[i];
+
+      if (phi->getOperand(i).isUndefined())
+         continue;
+
+      /* TODO: this is usually redundant */
+      aco_ptr<Instruction> cselect{create_instruction<SOP2_instruction>(aco_opcode::s_cselect_b32, Format::SOP2, 3, 1)};
+      cselect->getOperand(0) = Operand((uint32_t) -1);
+      cselect->getOperand(1) = Operand((uint32_t) 0);
+      cselect->getOperand(2) = Operand(phi->getOperand(i));
+      cselect->getOperand(2).setFixed(scc);
+      Temp new_src{program->allocateId(), s1};
+      cselect->getDefinition(0) = Definition(new_src);
+      insert_before_branch(pred, std::move(cselect));
+
+      phi->getOperand(i) = Operand(new_src);
+   }
+
+   Temp dst32{program->allocateId(), s1};
+
+   /* TODO: this should be placed later to minimize the definition's live range */
+   aco_ptr<Instruction> cmp{create_instruction<SOPC_instruction>(aco_opcode::s_cmp_lg_u32, Format::SOPC, 2, 1)};
+   cmp->getOperand(0) = Operand((uint32_t) 0);
+   cmp->getOperand(1) = Operand(dst32);
+   cmp->getDefinition(0) = phi->getDefinition(0);
+
+   phi->getDefinition(0) = Definition(dst32);
+
+   return cmp;
+}
+
+void lower_bool_phis(Program* program)
+{
+   for (std::vector<std::unique_ptr<Block>>::iterator it = program->blocks.begin(); it != program->blocks.end(); ++it)
+   {
+      Block* block = it->get();
+      std::vector<aco_ptr<Instruction>> instructions;
+      std::vector<aco_ptr<Instruction>> non_phi;
+      instructions.swap(block->instructions);
+      block->instructions.reserve(instructions.size());
+      unsigned i = 0;
+      for (; i < instructions.size(); i++)
+      {
+         aco_ptr<Instruction>& phi = instructions[i];
+         if (phi->opcode != aco_opcode::p_phi && phi->opcode != aco_opcode::p_linear_phi)
+            break;
+         if (phi->opcode == aco_opcode::p_phi && phi->getDefinition(0).regClass() == s2) {
+            non_phi.emplace_back(std::move(lower_divergent_bool_phi(program, block, phi)));
+         } else if (phi->opcode == aco_opcode::p_linear_phi && phi->getDefinition(0).regClass() == b) {
+            non_phi.emplace_back(std::move(lower_uniform_bool_phi(program, block, phi)));
+            block->instructions.emplace_back(std::move(phi));
+         } else {
+            block->instructions.emplace_back(std::move(phi));
+         }
+      }
+      for (auto&& instr : non_phi) {
+         assert(instr->opcode != aco_opcode::p_phi && instr->opcode != aco_opcode::p_linear_phi);
+         block->instructions.emplace_back(std::move(instr));
+      }
+      for (; i < instructions.size(); i++) {
+         aco_ptr<Instruction> instr = std::move(instructions[i]);
+         assert(instr->opcode != aco_opcode::p_phi && instr->opcode != aco_opcode::p_linear_phi);
+         block->instructions.emplace_back(std::move(instr));
+      }
+   }
+}
+
+}

--- a/src/amd/compiler/aco_lower_bool_phis.cpp
+++ b/src/amd/compiler/aco_lower_bool_phis.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 Valve Corporation
+ * Copyright © 2019 Valve Corporation
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),

--- a/src/amd/compiler/aco_lower_to_hw_instr.cpp
+++ b/src/amd/compiler/aco_lower_to_hw_instr.cpp
@@ -379,12 +379,8 @@ void lower_to_hw_instr(Program* program)
             }
             case aco_opcode::p_discard_if:
             {
-               if (instr->getOperand(0).regClass() == s1) {
-                  aco_ptr<SOPC_instruction> cmp{create_instruction<SOPC_instruction>(aco_opcode::s_cmp_lg_u32, Format::SOPC, 2, 1)};
-                  cmp->getOperand(0) = Operand(instr->getOperand(0));
-                  cmp->getOperand(1) = Operand((uint32_t) 0);
-                  cmp->getDefinition(0) = Definition(program->allocateId(), scc, b);
-                  ctx.instructions.emplace_back(std::move(cmp));
+               if (instr->getOperand(0).regClass() == b) {
+                  assert(instr->getOperand(0).isFixed() && instr->getOperand(0).physReg() == scc);
                } else {
                   assert(instr->getOperand(0).regClass() == s2);
                   aco_ptr<SOP2_instruction> sop2{create_instruction<SOP2_instruction>(aco_opcode::s_andn2_b64, Format::SOP2, 2, 2)};

--- a/src/amd/compiler/aco_opt_value_numbering.cpp
+++ b/src/amd/compiler/aco_opt_value_numbering.cpp
@@ -84,6 +84,8 @@ struct InstrPred {
          return false;
       if (a->opcode != b->opcode)
          return false;
+      if (a->num_operands != b->num_operands || a->num_definitions != b->num_definitions)
+         return false; /* possible with pseudo-instructions */
       for (unsigned i = 0; i < a->num_operands; i++) {
          if (a->getOperand(i).isConstant()) {
             if (!b->getOperand(i).isConstant())

--- a/src/amd/compiler/aco_optimizer.cpp
+++ b/src/amd/compiler/aco_optimizer.cpp
@@ -535,6 +535,7 @@ void label_instruction(opt_ctx &ctx, aco_ptr<Instruction>& instr)
       break;
    case aco_opcode::p_phi:
    case aco_opcode::p_linear_phi: {
+      /* lower_bool_phis() can create phis like this */
       bool all_same = instr->getOperand(0).isTemp();
       for (unsigned i = 1; all_same && (i < instr->operandCount()); i++) {
          if (!instr->getOperand(i).isTemp() || instr->getOperand(i).tempId() != instr->getOperand(0).tempId())

--- a/src/amd/compiler/aco_optimizer.cpp
+++ b/src/amd/compiler/aco_optimizer.cpp
@@ -533,6 +533,17 @@ void label_instruction(opt_ctx &ctx, aco_ptr<Instruction>& instr)
           instr->getOperand(1).isTemp() && ctx.info[instr->getOperand(1).tempId()].is_vcc())
          ctx.info[instr->getDefinition(0).tempId()].set_temp(ctx.info[instr->getOperand(1).tempId()].temp);
       break;
+   case aco_opcode::p_phi:
+   case aco_opcode::p_linear_phi: {
+      bool all_same = instr->getOperand(0).isTemp();
+      for (unsigned i = 1; all_same && (i < instr->operandCount()); i++) {
+         if (!instr->getOperand(i).isTemp() || instr->getOperand(i).tempId() != instr->getOperand(0).tempId())
+            all_same = false;
+      }
+      if (all_same)
+         ctx.info[instr->getDefinition(0).tempId()].set_temp(instr->getOperand(0).getTemp());
+      break;
+   }
    default:
       break;
    }

--- a/src/amd/compiler/aco_register_allocation.cpp
+++ b/src/amd/compiler/aco_register_allocation.cpp
@@ -604,7 +604,7 @@ void register_allocation(Program *program, std::vector<std::set<Temp>> live_out_
                   }
                   /* move operand to fixed reg and create parallelcopy pair */
                   Operand pc_op = operand;
-                  Temp tmp = Temp{program->allocateId(), operand.regClass()};
+                  Temp tmp = Temp{program->allocateId(), operand.physReg() == scc ? RegClass::b : operand.regClass()};
                   Definition pc_def = Definition(tmp);
                   pc_def.setFixed(operand.physReg());
                   pc_op.setFixed(assignments[operand.tempId()].first);

--- a/src/amd/compiler/aco_register_allocation.cpp
+++ b/src/amd/compiler/aco_register_allocation.cpp
@@ -550,7 +550,7 @@ void register_allocation(Program *program, std::vector<std::set<Temp>> live_out_
 
          /* update phi affinities */
          for (unsigned i = 0; i < phi->num_operands; i++) {
-            if (phi->getOperand(i).isTemp() && phi->getOperand(i).regClass() == phi->getDefinition(i).regClass())
+            if (phi->getOperand(i).isTemp() && phi->getOperand(i).regClass() == phi->getDefinition(0).regClass())
                affinities[phi->getOperand(i).tempId()] = definition.tempId();
          }
 

--- a/src/amd/compiler/aco_ssa_elimination.cpp
+++ b/src/amd/compiler/aco_ssa_elimination.cpp
@@ -42,7 +42,6 @@ struct ssa_elimination_ctx {
 
 void collect_phi_info(phi_info& ctx, aco_ptr<Instruction>& phi, std::vector<Block*> preds)
 {
-   assert(!(phi->opcode == aco_opcode::p_phi && phi->getDefinition(0).getTemp().type() == sgpr) && "smart merging for bools not yet implemented.");
    for (unsigned i = 0; i < preds.size(); i++)
    {
       if (phi->getOperand(i).isUndefined())

--- a/src/amd/compiler/aco_validate.cpp
+++ b/src/amd/compiler/aco_validate.cpp
@@ -147,7 +147,7 @@ void validate(Program* program, FILE * output)
                }
             } else if (instr->opcode == aco_opcode::p_phi) {
                check(instr->num_operands == block->logical_predecessors.size(), "Number of Operands does not match number of predecessors", instr.get());
-               check(instr->getDefinition(0).getTemp().type() == vgpr, "Logical Phi Definition must be vgpr", instr.get());
+               check(instr->getDefinition(0).getTemp().type() == vgpr || instr->getDefinition(0).getTemp().regClass() == s2, "Logical Phi Definition must be vgpr or divergent boolean", instr.get());
             } else if (instr->opcode == aco_opcode::p_linear_phi) {
                check(instr->num_operands == block->linear_predecessors.size(), "Number of Operands does not match number of predecessors", instr.get());
             }

--- a/src/amd/compiler/meson.build
+++ b/src/amd/compiler/meson.build
@@ -57,6 +57,7 @@ libaco_files = files(
   'aco_reduce_assign.cpp',
   'aco_register_allocation.cpp',
   'aco_live_var_analysis.cpp',
+  'aco_lower_bool_phis.cpp',
   'aco_lower_to_cssa.cpp',
   'aco_lower_to_hw_instr.cpp',
   'aco_optimizer.cpp',

--- a/src/amd/vulkan/radv_nir_to_llvm.c
+++ b/src/amd/vulkan/radv_nir_to_llvm.c
@@ -3471,8 +3471,10 @@ LLVMModuleRef ac_translate_nir_to_llvm(struct ac_llvm_compiler *ac_llvm,
 
 	memset(shader_info, 0, sizeof(*shader_info));
 
-	for(int i = 0; i < shader_count; ++i)
+	for(int i = 0; i < shader_count; ++i) {
+		nir_lower_bool_to_int32(shaders[i]);
 		radv_nir_shader_info_pass(shaders[i], options, &shader_info->info);
+	}
 
 	for (i = 0; i < RADV_UD_MAX_SETS; i++)
 		shader_info->user_sgprs_locs.descriptor_sets[i].sgpr_idx = -1;

--- a/src/amd/vulkan/radv_pipeline.c
+++ b/src/amd/vulkan/radv_pipeline.c
@@ -2087,10 +2087,6 @@ void radv_create_shaders(struct radv_pipeline *pipeline,
 		radv_link_shaders(pipeline, nir);
 
 	for (int i = 0; i < MESA_SHADER_STAGES; ++i) {
-		if (nir[i]) {
-			NIR_PASS_V(nir[i], nir_lower_bool_to_int32);
-		}
-
 		if (radv_can_dump_shader(device, modules[i], false))
 			nir_print_shader(nir[i], stderr);
 	}

--- a/src/amd/vulkan/radv_shader.c
+++ b/src/amd/vulkan/radv_shader.c
@@ -681,11 +681,18 @@ shader_variant_create(struct radv_device *device,
 			bool aco_compile_time = device->instance->debug_flags & RADV_DEBUG_COMPILETIME;
 			struct timespec user1,user2;
 			if (aco_compile_time) {
+				struct nir_shader *llvm_shaders[shader_count];
+				for (int i = 0; i < shader_count; i++)
+					llvm_shaders[i] = nir_shader_clone(ralloc_parent(shaders[i]), shaders[i]);
+
 				clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &user1);
 				radv_compile_nir_shader(&ac_llvm, &binary, &variant->config,
-							&variant->info, shaders, shader_count,
+							&variant->info, llvm_shaders, shader_count,
 							options);
 				clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &user2);
+
+				for (int i = 0; i < shader_count; i++)
+					ralloc_free(llvm_shaders[i]);
 
 				fprintf(stderr, "%3d: ", num++);
 				double user_elapsed = (user2.tv_sec*NANOS + user2.tv_nsec - (user1.tv_sec*NANOS + user1.tv_nsec)) / (double) (NANOS / 1000);


### PR DESCRIPTION
This PR has ACO consume 1-bit booleans instead of 32-bit booleans.
While doing this, it changes the boolean representation to have divergent booleans stored in two sgprs and one-bit booleans stored in scc.
This PR gives a -1% change in code size in SotTR, -0.13% change in Dota 2, -0.3% change in Talos.

It also includes a couple of fixes.