### PR TITLE
amd/compiler: implement proper WQM handling

### DIFF
--- a/src/amd/compiler/TODO
+++ b/src/amd/compiler/TODO
@@ -6,7 +6,6 @@ Features:
 - implement missing features for games or just CTS
 
 Fixes:
-- fix WQM for FS (see LLVM's SIWholeQuadMode.cpp)
 - fix discard_if to check if anywhere(!) are lanes active:
 	%tmp = active_lanes_at_start_of_program
 	%tmp = %tmp & ~cond . EXEC &= %tmp. if %tmp == 0 endpgm

--- a/src/amd/compiler/aco_instruction_selection.cpp
+++ b/src/amd/compiler/aco_instruction_selection.cpp
@@ -156,6 +156,40 @@ void emit_v_mov(isel_context *ctx, Temp src, Temp dst)
    }
 }
 
+Temp emit_wqm(isel_context *ctx, Temp src, Temp dst=Temp(0, s1))
+{
+   if (ctx->stage != MESA_SHADER_FRAGMENT) {
+      if (!dst.id())
+         return src;
+
+      if (src.type() == vgpr || src.size() > 1) {
+         emit_v_mov(ctx, src, dst);
+      } else {
+         aco_ptr<Instruction> mov(create_instruction<SOP1_instruction>(aco_opcode::s_mov_b32, Format::SOP1, 1, 1));
+         mov->getOperand(0) = Operand(src);
+         mov->getDefinition(0) = Definition(dst);
+         ctx->block->instructions.emplace_back(std::move(mov));
+      }
+      return dst;
+   }
+
+   if (!dst.id())
+      dst = {ctx->program->allocateId(), src.regClass()};
+
+   aco_ptr<Instruction> copy{create_instruction<Instruction>(aco_opcode::p_parallelcopy, Format::PSEUDO, 1, 1)};
+   Temp tmp{ctx->program->allocateId(), src.regClass()};
+   copy->getDefinition(0) = Definition(tmp);
+   copy->getOperand(0) = Operand(src);
+   ctx->block->instructions.emplace_back(std::move(copy));
+
+   aco_ptr<Instruction> wqm{create_instruction<Instruction>(aco_opcode::p_wqm, Format::PSEUDO, 1, 1)};
+   wqm->getOperand(0) = Operand(tmp);
+   wqm->getDefinition(0) = Definition(dst);
+   ctx->block->instructions.emplace_back(std::move(wqm));
+   ctx->program->needs_wqm = true;
+   return dst;
+}
+
 Temp as_vgpr(isel_context *ctx, Temp val)
 {
    if (val.type() == RegType::sgpr) {
@@ -2025,12 +2059,14 @@ void visit_alu_instr(isel_context *ctx, nir_alu_instr *instr)
             sub->dpp_ctrl = 0xAA;
       }
 
+      Temp tmp{ctx->program->allocateId(), v1};
       sub->getOperand(0) = Operand(get_alu_src(ctx, instr->src[0]));
       sub->getOperand(1) = Operand(tl);
-      sub->getDefinition(0) = Definition(dst);
+      sub->getDefinition(0) = Definition(tmp);
       sub->row_mask = 0xF;
       sub->bank_mask = 0xF;
       ctx->block->instructions.emplace_back(std::move(sub));
+      emit_wqm(ctx, tmp, dst);
       break;
    }
    case nir_op_urcp: {
@@ -3106,6 +3142,8 @@ void visit_image_store(isel_context *ctx, nir_intrinsic_instr *instr)
       store->getOperand(3) = Operand(data);
       store->idxen = true;
       store->glc = glc;
+      store->disable_wqm = true;
+      ctx->program->needs_exact = true;
       ctx->block->instructions.emplace_back(std::move(store));
       return;
    }
@@ -3123,6 +3161,8 @@ void visit_image_store(isel_context *ctx, nir_intrinsic_instr *instr)
    store->dmask = 0xF;
    store->unrm = true;
    store->da = should_declare_array(ctx, dim, glsl_sampler_type_is_array(type));
+   store->disable_wqm = true;
+   ctx->program->needs_exact = true;
    ctx->block->instructions.emplace_back(std::move(store));
    return;
 }
@@ -3219,6 +3259,8 @@ void visit_image_atomic(isel_context *ctx, nir_intrinsic_instr *instr)
       mubuf->offset = 0;
       mubuf->idxen = true;
       mubuf->glc = return_previous;
+      mubuf->disable_wqm = true;
+      ctx->program->needs_exact = true;
       ctx->block->instructions.emplace_back(std::move(mubuf));
       return;
    }
@@ -3235,6 +3277,8 @@ void visit_image_atomic(isel_context *ctx, nir_intrinsic_instr *instr)
    mimg->dmask = (1 << data.size()) - 1;
    mimg->unrm = true;
    mimg->da = should_declare_array(ctx, dim, glsl_sampler_type_is_array(type));
+   mimg->disable_wqm = true;
+   ctx->program->needs_exact = true;
    ctx->block->instructions.emplace_back(std::move(mimg));
    return;
 }
@@ -3451,6 +3495,8 @@ void visit_store_ssbo(isel_context *ctx, nir_intrinsic_instr *instr)
       store->offset = start;
       store->offen = (offset.type() == vgpr);
       store->glc = nir_intrinsic_access(instr) & (ACCESS_VOLATILE | ACCESS_COHERENT);
+      store->disable_wqm = true;
+      ctx->program->needs_exact = true;
       ctx->block->instructions.emplace_back(std::move(store));
    }
 }
@@ -3549,6 +3595,8 @@ void visit_atomic_ssbo(isel_context *ctx, nir_intrinsic_instr *instr)
    mubuf->offset = 0;
    mubuf->offen = (offset.type() == vgpr);
    mubuf->glc = return_previous;
+   mubuf->disable_wqm = true;
+   ctx->program->needs_exact = true;
    ctx->block->instructions.emplace_back(std::move(mubuf));
 }
 
@@ -4161,12 +4209,14 @@ void visit_intrinsic(isel_context *ctx, nir_intrinsic_instr *instr)
       // reduce sequence
       reduce->getOperand(1) = Operand();
 
-      reduce->getDefinition(0) = Definition(dst);
+      Temp tmp_dst{ctx->program->allocateId(), dst.regClass()};
+      reduce->getDefinition(0) = Definition(tmp_dst);
       reduce->getDefinition(1) = Definition(stmp);
       reduce->getDefinition(2) = Definition(scc, b); // clobbers scc
       reduce->reduce_op = reduce_op;
       reduce->cluster_size = cluster_size;
       ctx->block->instructions.emplace_back(std::move(reduce));
+      emit_wqm(ctx, tmp_dst, dst);
       break;
    }
    default:
@@ -4582,6 +4632,11 @@ void visit_tex(isel_context *ctx, nir_tex_instr *instr)
       assert(util_bitcount(dmask) == instr->dest.ssa.num_components);
       return;
    }
+
+   if (!(has_ddx && has_ddy) && !has_lod && !level_zero &&
+       instr->sampler_dim != GLSL_SAMPLER_DIM_MS &&
+       instr->sampler_dim != GLSL_SAMPLER_DIM_SUBPASS_MS)
+      coords = emit_wqm(ctx, coords);
 
    std::vector<Operand> args;
    if (has_offset)
@@ -5510,15 +5565,6 @@ std::unique_ptr<Program> select_program(struct nir_shader *nir,
 {
    std::unique_ptr<Program> program{new Program};
    isel_context ctx = setup_isel_context(program.get(), nir, config, info, options);
-
-   // TODO: this is more a workaround until we have proper wqm handling
-   if (ctx.stage == MESA_SHADER_FRAGMENT) {
-      aco_ptr<Instruction> wqm{create_instruction<Instruction>(aco_opcode::s_wqm_b64, Format::SOP1, 1, 2)};
-      wqm->getOperand(0) = Operand(PhysReg{126}, s2);
-      wqm->getDefinition(0) = Definition(PhysReg{126}, s2);
-      wqm->getDefinition(1) = Definition(program->allocateId(), scc, b);
-      ctx.block->instructions.push_back(std::move(wqm));
-   }
 
    append_logical_start(ctx.block);
 

--- a/src/amd/compiler/aco_instruction_selection.cpp
+++ b/src/amd/compiler/aco_instruction_selection.cpp
@@ -4901,7 +4901,9 @@ void visit_jump(isel_context *ctx, nir_jump_instr *instr)
          aco_instr->getOperand(1) = Operand(exec, s2);
          ctx->cf_info.parent_loop.active_mask = {ctx->program->allocateId(), s2};
          aco_instr->getDefinition(0) = Definition(ctx->cf_info.parent_loop.active_mask);
-         aco_instr->getDefinition(1) = Definition(ctx->program->allocateId(), scc, b);
+         Temp branch_cond{ctx->program->allocateId(), b};
+         aco_instr->getDefinition(1) = Definition(branch_cond);
+         aco_instr->getDefinition(1).setFixed(scc);
          ctx->block->instructions.emplace_back(std::move(aco_instr));
 
          /* set exec zero */
@@ -4913,7 +4915,8 @@ void visit_jump(isel_context *ctx, nir_jump_instr *instr)
 
          /* exit loop if needed */
          branch.reset(create_instruction<Pseudo_branch_instruction>(aco_opcode::p_cbranch_z, Format::PSEUDO_BRANCH, 1, 0));
-         branch->getOperand(0) = Operand(scc, b);
+         branch->getOperand(0) = Operand(branch_cond);
+         branch->getOperand(0).setFixed(scc);
          branch->targets[0] = ctx->cf_info.parent_loop.exit;
          branch->targets[1] = break_block;
          ctx->block->instructions.emplace_back(std::move(branch));
@@ -4927,17 +4930,21 @@ void visit_jump(isel_context *ctx, nir_jump_instr *instr)
          break_block->loop_nest_depth = ctx->cf_info.loop_nest_depth;
 
          /* there might be still active lanes due to previous continue */
-         aco_instr.reset(create_instruction<SOP1_instruction>(aco_opcode::s_andn2_saveexec_b64, Format::SOP1, 2, 2));
+         aco_instr.reset(create_instruction<SOP1_instruction>(aco_opcode::s_andn2_saveexec_b64, Format::SOP1, 2, 3));
          aco_instr->getOperand(0) = Operand(ctx->cf_info.parent_loop.active_mask);
          aco_instr->getOperand(1) = Operand(exec, s2);
          Temp temp = {ctx->program->allocateId(), s2};
          aco_instr->getDefinition(0) = Definition(temp);
-         aco_instr->getDefinition(1) = Definition(ctx->program->allocateId(), scc, b);
+         Temp branch_cond{ctx->program->allocateId(), b};
+         aco_instr->getDefinition(1) = Definition(branch_cond);
+         aco_instr->getDefinition(1).setFixed(scc);
+         aco_instr->getDefinition(2) = Definition(exec, s2);
          ctx->block->instructions.emplace_back(std::move(aco_instr));
 
          /* branch to loop entry if still lanes are active */
          branch.reset(create_instruction<Pseudo_branch_instruction>(aco_opcode::p_cbranch_nz, Format::PSEUDO_BRANCH, 1, 0));
-         branch->getOperand(0) = Operand(scc, b);
+         branch->getOperand(0) = Operand(branch_cond);
+         branch->getOperand(0).setFixed(scc);
          branch->targets[0] = ctx->cf_info.parent_loop.entry;
          branch->targets[1] = break_block;
          ctx->block->instructions.emplace_back(std::move(branch));
@@ -5299,11 +5306,14 @@ static void visit_if(isel_context *ctx, nir_if *if_stmt)
       append_logical_end(BB_if);
 
       /* create the exec mask for then branch */
-      aco_ptr<SOP1_instruction> set_exec{create_instruction<SOP1_instruction>(aco_opcode::s_and_saveexec_b64, Format::SOP1, 1, 2)};
+      aco_ptr<SOP1_instruction> set_exec{create_instruction<SOP1_instruction>(aco_opcode::s_and_saveexec_b64, Format::SOP1, 1, 3)};
       set_exec->getOperand(0) = Operand(cond);
       Temp orig_exec = {ctx->program->allocateId(), s2};
       set_exec->getDefinition(0) = Definition(orig_exec);
       set_exec->getDefinition(1) = Definition(ctx->program->allocateId(), scc, b);
+      Temp branch_cond{ctx->program->allocateId(), s2};
+      set_exec->getDefinition(2) = Definition(branch_cond);
+      set_exec->getDefinition(2).setFixed(exec);
       BB_if->instructions.push_back(std::move(set_exec));
 
       /* create the exec mask for else branch */
@@ -5317,7 +5327,8 @@ static void visit_if(isel_context *ctx, nir_if *if_stmt)
 
       /* branch to linear then block */
       branch.reset(create_instruction<Pseudo_branch_instruction>(aco_opcode::p_cbranch_z, Format::PSEUDO_BRANCH, 1, 0));
-      branch->getOperand(0) = Operand(exec, s2);
+      branch->getOperand(0) = Operand(branch_cond);
+      branch->getOperand(0).setFixed(exec);
       branch->targets[0] = BB_then_linear;
       branch->targets[1] = BB_then_logical;
       BB_if->instructions.push_back(std::move(branch));
@@ -5382,14 +5393,11 @@ static void visit_if(isel_context *ctx, nir_if *if_stmt)
       Temp then_mask = {ctx->program->allocateId(), s2};
       mov->getDefinition(0) = Definition(then_mask);
       BB_between->instructions.push_back(std::move(mov));
-      mov.reset(create_instruction<SOP1_instruction>(aco_opcode::s_mov_b64, Format::SOP1, 1, 1));
-      mov->getOperand(0) = Operand(else_mask);
-      mov->getDefinition(0) = Definition(exec, s2);
-      BB_between->instructions.push_back(std::move(mov));
 
       /* branch to linear else block (skip else) */
       branch.reset(create_instruction<Pseudo_branch_instruction>(aco_opcode::p_cbranch_z, Format::PSEUDO_BRANCH, 1, 0));
-      branch->getOperand(0) = Operand(PhysReg{126}, s2);
+      branch->getOperand(0) = Operand(else_mask);
+      branch->getOperand(0).setFixed(exec);
       branch->targets[0] = BB_else_linear;
       branch->targets[1] = BB_else_logical;
       BB_between->instructions.push_back(std::move(branch));

--- a/src/amd/compiler/aco_interface.cpp
+++ b/src/amd/compiler/aco_interface.cpp
@@ -70,11 +70,12 @@ void aco_compile_shader(struct nir_shader *shader, struct ac_shader_config* conf
    aco::validate(program.get(), stderr);
 
    aco::live live_vars = aco::live_var_analysis<true>(program.get(), options);
-   aco::spill(program.get(), live_vars, options);
 
    //std::cerr << "Before Schedule:\n";
    //aco_print_program(program.get(), stderr);
    aco::schedule_program(program.get(), live_vars);
+
+   aco::spill(program.get(), live_vars, options);
 
    /* Register Allocation */
    aco::register_allocation(program.get(), live_vars.live_out);

--- a/src/amd/compiler/aco_interface.cpp
+++ b/src/amd/compiler/aco_interface.cpp
@@ -75,6 +75,11 @@ void aco_compile_shader(struct nir_shader *shader, struct ac_shader_config* conf
    //aco_print_program(program.get(), stderr);
    aco::schedule_program(program.get(), live_vars);
 
+   if (program->stage == MESA_SHADER_FRAGMENT) {
+      if (aco::lower_wqm(program.get()))
+         live_vars = aco::live_var_analysis<true>(program.get(), options);
+   }
+
    aco::spill(program.get(), live_vars, options);
 
    /* Register Allocation */

--- a/src/amd/compiler/aco_ir.h
+++ b/src/amd/compiler/aco_ir.h
@@ -708,6 +708,7 @@ struct MUBUF_instruction : public Instruction {
    bool slc; /* system level coherent */
    bool tfe; /* texture fail enable */
    bool lds; /* Return read-data to LDS instead of VGPRs */
+   bool disable_wqm; /* Require an exec mask without helper invocations */
 };
 
 /**
@@ -731,6 +732,7 @@ struct MIMG_instruction : public Instruction {
       bool a16; /* VEGA: Address components are 16-bits */
    };
    bool d16; /* Convert 32-bit data to 16-bit data */
+   bool disable_wqm; /* Require an exec mask without helper invocations */
 };
 
 struct Export_instruction : public Instruction {
@@ -823,6 +825,8 @@ public:
    struct radv_shader_variant_info *info;
    enum chip_class chip_class;
    gl_shader_stage stage;
+   bool needs_exact = false; /* there exists an instruction with disable_wqm = true */
+   bool needs_wqm = false; /* there exists a p_wqm instruction */
 
    uint32_t allocateId()
    {
@@ -863,6 +867,7 @@ std::unique_ptr<Program> select_program(struct nir_shader *nir,
                                         struct radv_shader_variant_info *info,
                                         struct radv_nir_compiler_options *options);
 
+bool lower_wqm(Program* program);
 void lower_bool_phis(Program* program);
 void update_vgpr_sgpr_demand(Program* program, unsigned vgpr, unsigned sgpr);
 template<bool condition>

--- a/src/amd/compiler/aco_lower_to_hw_instr.cpp
+++ b/src/amd/compiler/aco_lower_to_hw_instr.cpp
@@ -125,10 +125,11 @@ void emit_reduce(lower_context *ctx, aco_opcode op, ReduceOp reduce_op, unsigned
    invert_exec(ctx);
 
    // note: this clobbers SCC!
-   aco_ptr<SOP1_instruction> set_exec{create_instruction<SOP1_instruction>(aco_opcode::s_or_saveexec_b64, Format::SOP1, 1, 2)};
+   aco_ptr<SOP1_instruction> set_exec{create_instruction<SOP1_instruction>(aco_opcode::s_or_saveexec_b64, Format::SOP1, 1, 3)};
    set_exec->getOperand(0) = Operand((uint64_t) -1);
    set_exec->getDefinition(0) = Definition(stmp, s2);
    set_exec->getDefinition(1) = Definition(scc, b);
+   set_exec->getDefinition(2) = Definition(exec, s2);
    ctx->instructions.emplace_back(std::move(set_exec));
 
    // TODO: generalize this!

--- a/src/amd/compiler/aco_lower_to_hw_instr.cpp
+++ b/src/amd/compiler/aco_lower_to_hw_instr.cpp
@@ -462,6 +462,11 @@ void lower_to_hw_instr(Program* program)
                }
                break;
             }
+            case aco_opcode::p_wqm:
+            {
+               assert(instr->getOperand(0).physReg() == instr->getDefinition(0).physReg());
+               break;
+            }
             default:
                ctx.instructions.emplace_back(std::move(instr));
                break;

--- a/src/amd/compiler/aco_opcodes.py
+++ b/src/amd/compiler/aco_opcodes.py
@@ -153,6 +153,8 @@ opcode("p_reload")
 opcode("p_start_linear_vgpr")
 opcode("p_end_linear_vgpr")
 
+opcode("p_wqm")
+
 # SOP2 instructions: 2 scalar inputs, 1 scalar output (+optional scc)
 SOP2_SCC = {
    (0, "s_add_u32"), 

--- a/src/amd/compiler/aco_optimizer.cpp
+++ b/src/amd/compiler/aco_optimizer.cpp
@@ -467,7 +467,9 @@ void label_instruction(opt_ctx &ctx, aco_ptr<Instruction>& instr)
    case aco_opcode::s_mov_b64:
    case aco_opcode::v_mov_b32:
    case aco_opcode::v_readfirstlane_b32:
-      if (instr->getOperand(0).isConstant()) {
+      if (instr->getDefinition(0).isFixed()) {
+         /* don't copy-propagate copies into fixed registers */
+      } else if (instr->getOperand(0).isConstant()) {
          if (instr->getOperand(0).isLiteral())
             ctx.info[instr->getDefinition(0).tempId()].set_literal(instr->getOperand(0).constantValue());
          else

--- a/src/amd/compiler/aco_register_allocation.cpp
+++ b/src/amd/compiler/aco_register_allocation.cpp
@@ -895,7 +895,10 @@ void register_allocation(Program *program, std::vector<std::set<Temp>> live_out_
                else if (instr->opcode == aco_opcode::s_addk_i32 ||
                         instr->opcode == aco_opcode::s_mulk_i32)
                   definition.setFixed(instr->getOperand(0).physReg());
-               else if ((instr->format == Format::MUBUF ||
+               else if (instr->opcode == aco_opcode::p_wqm) {
+                  assert(instr->getOperand(0).isKill());
+                  definition.setFixed(instr->getOperand(0).physReg());
+               } else if ((instr->format == Format::MUBUF ||
                          instr->format == Format::MIMG) &&
                         instr->num_definitions == 1 &&
                         instr->num_operands == 4)

--- a/src/amd/compiler/aco_scheduler_postRA.cpp
+++ b/src/amd/compiler/aco_scheduler_postRA.cpp
@@ -97,22 +97,6 @@ bool reads_exec_implicitly(Instruction* instr)
 
 bool writes_exec_implicitly(Instruction* instr)
 {
-   if (instr->isSALU()) {
-      switch (instr->opcode) {
-         case aco_opcode::s_and_saveexec_b64:
-         case aco_opcode::s_or_saveexec_b64:
-         case aco_opcode::s_xor_saveexec_b64:
-         case aco_opcode::s_andn2_saveexec_b64:
-         case aco_opcode::s_orn2_saveexec_b64:
-         case aco_opcode::s_nand_saveexec_b64:
-         case aco_opcode::s_nor_saveexec_b64:
-         case aco_opcode::s_xnor_saveexec_b64:
-            return true;
-         default:
-            return false;
-      }
-   }
-
    // TODO v_cmpx_*
    return false;
 }

--- a/src/amd/compiler/aco_wqm.cpp
+++ b/src/amd/compiler/aco_wqm.cpp
@@ -1,0 +1,393 @@
+/*
+ * Copyright © 2019 Valve Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * Authors:
+ *    Rhys Perry (pendingchaos02@gmail.com)
+ *
+ */
+
+#include <unordered_map>
+#include <vector>
+
+#include "aco_ir.h"
+
+
+namespace aco {
+
+enum WQMState : uint8_t {
+   Unspecified = 0,
+   Exact = 1 << 0,
+   WQM = 1 << 1 /* with control flow applied */
+};
+
+struct block_info
+{
+   std::vector<WQMState> instr_needs;
+   bool wqm; /* true if the branch condition in this block should be in wqm */
+};
+
+struct wqm_ctx
+{
+   Program *program;
+   std::vector<block_info> blocks;
+   Temp exact_mask;
+
+   /* state for WQM propagation */
+   std::vector<uint16_t> defined_in;
+   std::set<unsigned> propagate_worklist;
+   std::vector<bool> needs_wqm;
+
+   /* process_block() state */
+   Temp wqm_exec_mask;
+};
+
+bool pred_by_exec_mask(aco_ptr<Instruction>& instr) {
+   if (instr->format == Format::SMEM || instr->isSALU())
+      return false;
+   if (instr->format == Format::PSEUDO_BARRIER)
+      return false;
+
+   if (instr->format == Format::PSEUDO) {
+      switch (instr->opcode) {
+      case aco_opcode::p_extract_vector:
+      case aco_opcode::p_create_vector:
+      case aco_opcode::p_split_vector:
+         return instr->getDefinition(0).getTemp().type() == RegType::vgpr;
+      case aco_opcode::p_spill:
+      case aco_opcode::p_reload:
+         return false;
+      default:
+         break;
+      }
+   }
+
+   if (instr->opcode == aco_opcode::v_readlane_b32 ||
+       instr->opcode == aco_opcode::v_writelane_b32)
+      return false;
+
+   return true;
+}
+
+bool directly_reads_exec(Instruction* instr)
+{
+   if (instr->isSALU()) {
+      switch (instr->opcode) {
+         case aco_opcode::s_and_saveexec_b64:
+         case aco_opcode::s_or_saveexec_b64:
+         case aco_opcode::s_xor_saveexec_b64:
+         case aco_opcode::s_andn2_saveexec_b64:
+         case aco_opcode::s_orn2_saveexec_b64:
+         case aco_opcode::s_nand_saveexec_b64:
+         case aco_opcode::s_nor_saveexec_b64:
+         case aco_opcode::s_xnor_saveexec_b64:
+            return true;
+         default:
+            break;
+      }
+   }
+
+   if (instr->opcode == aco_opcode::p_discard_if)
+      return true;
+
+   bool isVOPC = ((uint16_t) instr->format & (uint16_t) Format::VOPC) == (uint16_t) Format::VOPC;
+   if (!isVOPC && instr->isVALU()) {
+      switch (instr->opcode) {
+      case aco_opcode::v_cndmask_b32:
+      case aco_opcode::v_writelane_b32:
+      case aco_opcode::v_addc_co_u32:
+      case aco_opcode::v_subb_co_u32:
+      case aco_opcode::v_subbrev_co_u32:
+         break;
+      default:
+         return false;
+      }
+   } else if (instr->format == Format::DS || instr->format == Format::EXP) {
+      return false;
+   }
+
+   for (unsigned i = 0; i < instr->operandCount(); i++) {
+      Operand &op = instr->getOperand(i);
+      if (op.isFixed() && op.physReg().reg + op.size() >= exec.reg && op.physReg().reg <= exec.reg + 1)
+         return true;
+   }
+   
+   return false;
+}
+
+bool writes_exec(Instruction* instr)
+{
+   if (instr->isSALU()) {
+      switch (instr->opcode) {
+         case aco_opcode::s_and_saveexec_b64:
+         case aco_opcode::s_or_saveexec_b64:
+         case aco_opcode::s_xor_saveexec_b64:
+         case aco_opcode::s_andn2_saveexec_b64:
+         case aco_opcode::s_orn2_saveexec_b64:
+         case aco_opcode::s_nand_saveexec_b64:
+         case aco_opcode::s_nor_saveexec_b64:
+         case aco_opcode::s_xnor_saveexec_b64:
+            return true;
+         default:
+            break;
+      }
+   }
+
+   if (instr->opcode >= aco_opcode::v_cmpx_class_f16 &&
+       instr->opcode <= aco_opcode::v_cmpx_u_f64)
+      return true;
+
+   bool isVOPC = ((uint16_t) instr->format & (uint16_t) Format::VOPC) == (uint16_t) Format::VOPC;
+   if (!isVOPC && instr->isVALU()) {
+      switch (instr->opcode) {
+      case aco_opcode::v_add_co_u32:
+      case aco_opcode::v_sub_co_u32:
+      case aco_opcode::v_subrev_co_u32:
+      case aco_opcode::v_readfirstlane_b32:
+      case aco_opcode::v_readlane_b32:
+      case aco_opcode::v_addc_co_u32:
+      case aco_opcode::v_subb_co_u32:
+      case aco_opcode::v_subbrev_co_u32:
+         break;
+      default:
+         return false;
+      }
+   } else if (instr->format == Format::DS || instr->format == Format::EXP ||
+              instr->format == Format::FLAT || instr->format == Format::GLOBAL ||
+              instr->format == Format::SCRATCH) {
+      return false;
+   }
+
+   for (unsigned i = 0; i < instr->definitionCount(); i++) {
+      Definition &def = instr->getDefinition(i);
+      if (def.isFixed() && def.physReg().reg + def.size() >= exec.reg && def.physReg().reg <= exec.reg + 1)
+         return true;
+   }
+   
+   return false;
+}
+
+bool needs_exact(aco_ptr<Instruction>& instr) {
+   if (instr->format == Format::MUBUF) {
+      MUBUF_instruction *mubuf = static_cast<MUBUF_instruction *>(instr.get());
+      return mubuf->disable_wqm;
+   } else if (instr->format == Format::MIMG) {
+      MIMG_instruction *mimg = static_cast<MIMG_instruction *>(instr.get());
+      return mimg->disable_wqm;
+   } else {
+      return false;
+   }
+}
+
+void set_needs_wqm(wqm_ctx &ctx, Block *block, Temp tmp)
+{
+   if (!ctx.needs_wqm[tmp.id()]) {
+      ctx.needs_wqm[tmp.id()] = true;
+      if (ctx.defined_in[tmp.id()] != 0xFFFF)
+         ctx.propagate_worklist.insert(ctx.defined_in[tmp.id()]);
+   }
+}
+
+void mark_block_wqm(wqm_ctx &ctx, Block *block)
+{
+   if (ctx.blocks[block->index].wqm)
+      return;
+   ctx.blocks[block->index].wqm = true;
+
+   aco_ptr<Instruction>& branch = *block->instructions.rbegin();
+   if (branch->opcode != aco_opcode::p_branch) {
+      assert(branch->operandCount() && branch->getOperand(0).isTemp());
+      set_needs_wqm(ctx, block, branch->getOperand(0).getTemp());
+   }
+
+   for (Block *pred : block->logical_predecessors)
+      mark_block_wqm(ctx, pred);
+}
+
+/* ensure the condition controlling the control flow for this phi is in WQM */
+void mark_phi_wqm(wqm_ctx &ctx, Block *block)
+{
+   /* TODO: this sets more branch conditions to WQM than it needs to */
+   for (Block *pred : block->logical_predecessors)
+      mark_block_wqm(ctx, pred);
+}
+
+void get_block_needs(wqm_ctx &ctx, block_info *info, Block* block)
+{
+   info->instr_needs.resize(block->instructions.size());
+
+   for (int i = block->instructions.size() - 1; i >= 0; --i)
+   {
+      aco_ptr<Instruction>& instr = block->instructions[i];
+
+      WQMState needs = needs_exact(instr) ? Exact : Unspecified;
+      bool propagate_wqm = instr->opcode == aco_opcode::p_wqm;
+
+      bool pred_by_exec = pred_by_exec_mask(instr);
+      for (unsigned j = 0; j < instr->definitionCount(); j++) {
+         if (!instr->getDefinition(j).isTemp())
+            continue;
+         unsigned def = instr->getDefinition(j).tempId();
+         ctx.defined_in[def] = block->index;
+         if (pred_by_exec && needs == Unspecified && ctx.needs_wqm[def]) {
+            needs = WQM;
+            propagate_wqm = true;
+         }
+      }
+
+      if (propagate_wqm) {
+         for (unsigned j = 0; j < instr->operandCount(); j++) {
+            if (!instr->getOperand(j).isTemp())
+               continue;
+            set_needs_wqm(ctx, block, instr->getOperand(j).getTemp());
+         }
+      }
+
+      if (needs == WQM && instr->opcode == aco_opcode::p_phi)
+         mark_phi_wqm(ctx, block);
+
+      info->instr_needs[i] = needs;
+   }
+}
+
+WQMState transition_state(wqm_ctx &ctx, std::vector<aco_ptr<Instruction>>& instrs, WQMState from, WQMState to)
+{
+   if (from == to)
+      return to;
+
+   if (to == WQM) {
+      /* Unspecified/Exact -> WQM */
+      assert(ctx.wqm_exec_mask.id());
+      aco_ptr<Instruction> mov{create_instruction<SOP1_instruction>(aco_opcode::s_mov_b64, Format::SOP1, 1, 1)};
+      mov->getOperand(0) = Operand(ctx.wqm_exec_mask);
+      mov->getDefinition(0) = Definition(exec, s2);
+      instrs.emplace_back(std::move(mov));
+      ctx.wqm_exec_mask = Temp(0, s1);
+      return WQM;
+   } else if (to == Exact) {
+      /* Unspecified/WQM -> Exact */
+      ctx.wqm_exec_mask = {ctx.program->allocateId(), s2};
+      aco_ptr<Instruction> instr{create_instruction<SOP2_instruction>(aco_opcode::s_and_saveexec_b64, Format::SOP1, 1, 3)};
+      instr->getOperand(0) = Operand(ctx.exact_mask);
+      instr->getDefinition(0) = Definition(ctx.wqm_exec_mask);
+      instr->getDefinition(1) = Definition(ctx.program->allocateId(), scc, b);
+      instr->getDefinition(2) = Definition(exec, s2);
+      instrs.emplace_back(std::move(instr));
+      return Exact;
+   } else {
+      assert(to == Unspecified);
+      return from;
+   }
+}
+
+void process_block(wqm_ctx &ctx, block_info *info, Block *block)
+{
+   std::vector<aco_ptr<Instruction>> instructions;
+   instructions.swap(block->instructions);
+   block->instructions.reserve(instructions.size());
+
+   WQMState state = WQM;
+
+   unsigned i = 0;
+   if (block->index == 0 && instructions.size() && instructions[0]->opcode == aco_opcode::p_startpgm) {
+      block->instructions.emplace_back(std::move(instructions[0]));
+      i = 1;
+   }
+
+   if (block->index == 0) {
+      ctx.exact_mask = {ctx.program->allocateId(), s2};
+      aco_ptr<Instruction> mov{create_instruction<SOP1_instruction>(aco_opcode::s_mov_b64, Format::SOP1, 1, 1)};
+      mov->getOperand(0) = Operand(exec, s2);
+      mov->getDefinition(0) = Definition(ctx.exact_mask);
+      block->instructions.emplace_back(std::move(mov));
+
+      aco_ptr<Instruction> wqm{create_instruction<SOP1_instruction>(aco_opcode::s_wqm_b64, Format::SOP1, 1, 2)};
+      wqm->getOperand(0) = Operand(exec, s2);
+      wqm->getDefinition(0) = Definition(exec, s2);
+      wqm->getDefinition(1) = Definition(ctx.program->allocateId(), scc, b);
+      block->instructions.emplace_back(std::move(wqm));
+   }
+
+   for (; i < instructions.size(); i++) {
+      aco_ptr<Instruction> instr = std::move(instructions[i]);
+
+      WQMState needs = info->instr_needs[i];
+
+      if (instr->format == Format::PSEUDO_BRANCH || directly_reads_exec(instr.get())) {
+         assert(needs == Unspecified || needs == WQM);
+         needs = WQM;
+      }
+
+      state = transition_state(ctx, block->instructions, state, needs);
+
+      /* transitioning from Exact to WQM could overwrite it */
+      if (writes_exec(instr.get()))
+         state = WQM;
+
+      block->instructions.emplace_back(std::move(instr));
+   }
+}
+
+bool lower_wqm(Program *program)
+{
+   if (program->needs_wqm && !program->needs_exact) {
+      Block *block = program->blocks[0].get();
+      aco_ptr<Instruction> wqm{create_instruction<SOP1_instruction>(aco_opcode::s_wqm_b64, Format::SOP1, 1, 2)};
+      wqm->getOperand(0) = Operand(exec, s2);
+      wqm->getDefinition(0) = Definition(exec, s2);
+      wqm->getDefinition(1) = Definition(program->allocateId(), scc, b);
+      if (block->instructions.size() && block->instructions[0]->opcode == aco_opcode::p_startpgm)
+         block->instructions.emplace(std::next(block->instructions.begin()), std::move(wqm));
+      else
+         block->instructions.emplace(block->instructions.begin(), std::move(wqm));
+      return false;
+   } else if (!program->needs_wqm) {
+      return false;
+   }
+
+   wqm_ctx ctx;
+   ctx.program = program;
+   ctx.blocks.resize(program->blocks.size());
+   ctx.defined_in.resize(program->peekAllocationId());
+   memset(ctx.defined_in.data(), 0xFF, ctx.defined_in.size() * 2);
+   ctx.needs_wqm.resize(program->peekAllocationId());
+
+   for (unsigned i = 0; i < program->blocks.size(); ++i)
+      ctx.propagate_worklist.insert(i);
+
+   while (!ctx.propagate_worklist.empty()) {
+      unsigned block_index = *std::prev(ctx.propagate_worklist.end());
+      ctx.propagate_worklist.erase(std::prev(ctx.propagate_worklist.end()));
+
+      Block *block = program->blocks[block_index].get();
+      block_info *info = &ctx.blocks[block_index];
+      get_block_needs(ctx, info, block);
+   }
+
+   for (std::vector<std::unique_ptr<Block>>::iterator it = program->blocks.begin(); it != program->blocks.end(); ++it) {
+      Block *block = it->get();
+      block_info *info = &ctx.blocks[block->index];
+      process_block(ctx, info, block);
+   }
+
+   return true;
+}
+}

--- a/src/amd/compiler/meson.build
+++ b/src/amd/compiler/meson.build
@@ -68,6 +68,7 @@ libaco_files = files(
   'aco_ssa_elimination.cpp',
   'aco_spill.cpp',
   'aco_validate.cpp',
+  'aco_wqm.cpp',
 )
 
 libaco = static_library(


### PR DESCRIPTION
This adds a new pseudo-instruction: p_wqm. Usage of this instruction
indicates that the operand should be computed for the whole quad.
Also, MUBUF and MIMG instructions have a new field (set during instruction
selection) "disable_wqm" which indicates that the instruction should
not be executed for helper invocations.

If a shader doesn't have any p_wqm instructions or doesn't set
disable_wqm, lower_wqm() is either a no-op or just inserts a s_wqm_b64
at the beginning of the shader.

Also included are a few fixes/changed useful for WQM handling.