### PR TITLE
Be more consistent in live_var_analysis

### DIFF
--- a/src/amd/compiler/aco_ir.h
+++ b/src/amd/compiler/aco_ir.h
@@ -868,6 +868,10 @@ struct RegisterDemand {
       return a.vgpr == b.vgpr && a.sgpr == b.sgpr;
    }
 
+   constexpr bool exceeds(const RegisterDemand other) {
+      return vgpr > other.vgpr || sgpr > other.sgpr;
+   }
+
    RegisterDemand operator+(const Temp t) {
       if (t.type() == RegType::sgpr)
          return RegisterDemand( vgpr, sgpr + t.size() );


### PR DESCRIPTION
The naming convention changes within the same function. 

Stay consistent and use the temporary flag inserted

Btw is there any reason this is a std::set rather than an std::unordered_set?

I dont really see the necessity of the ordering