### PR TITLE
Refactor aco::Instruction

### DIFF
--- a/src/amd/compiler/aco_assembler.cpp
+++ b/src/amd/compiler/aco_assembler.cpp
@@ -326,12 +326,9 @@ void emit_instruction(asm_context& ctx, std::vector<uint32_t>& out, Instruction*
    }
 
    /* append literal dword */
-   for (unsigned i = 0; i < instr->operands.size(); i++)
-   {
-      if (instr->operands[i].isLiteral())
-      {
-         uint32_t literal = instr->operands[i].constantValue();
-         out.push_back(literal);
+   for (const Operand& op : instr->operands) {
+      if (op.isLiteral()) {
+         out.push_back(op.constantValue());
          break;
       }
    }

--- a/src/amd/compiler/aco_assembler.cpp
+++ b/src/amd/compiler/aco_assembler.cpp
@@ -80,7 +80,7 @@ void emit_instruction(asm_context& ctx, std::vector<uint32_t>& out, Instruction*
       encoding |= opcode << 18;
       if (instr->operands.size() >= 2)
          encoding |= instr->operands[1].isConstant() ? 1 << 17 : 0;
-      bool soe = instr->operands.size() >= (instr->definitions.size() ? 3 : 4);
+      bool soe = instr->operands.size() >= (!instr->definitions.empty() ? 3 : 4);
       assert(!soe || ctx.chip_class >= GFX9);
       encoding |= soe ? 1 << 14 : 0;
       encoding |= smem->glc ? 1 << 16 : 0;
@@ -208,7 +208,7 @@ void emit_instruction(asm_context& ctx, std::vector<uint32_t>& out, Instruction*
       encoding |= (0xF & mimg->dmask) << 8;
       out.push_back(encoding);
       encoding = (0xFF & instr->operands[0].physReg().reg); /* VADDR */
-      if (instr->definitions.size()) {
+      if (!instr->definitions.empty()) {
          encoding |= (0xFF & instr->definitions[0].physReg().reg) << 8; /* VDATA */
       } else if (instr->operands.size() == 4) {
          encoding |= (0xFF & instr->operands[3].physReg().reg) << 8; /* VDATA */
@@ -236,7 +236,7 @@ void emit_instruction(asm_context& ctx, std::vector<uint32_t>& out, Instruction*
       encoding |= flat->slc ? 1 << 13 : 0;
       out.push_back(encoding);
       encoding = (0xFF & instr->operands[0].physReg().reg);
-      if (instr->definitions.size())
+      if (!instr->definitions.empty())
          encoding |= (0xFF & instr->definitions[0].physReg().reg) << 24;
       else
          encoding |= (0xFF & instr->operands[2].physReg().reg) << 8;

--- a/src/amd/compiler/aco_builder_h.py
+++ b/src/amd/compiler/aco_builder_h.py
@@ -88,7 +88,7 @@ public:
       }
 
       operator Temp() const {
-         return instr->getDefinition(0).getTemp();
+         return instr->definitions[0].getTemp();
       }
 
       operator Operand() const {
@@ -96,7 +96,7 @@ public:
       }
 
       Definition& def(unsigned index) const {
-         return instr->getDefinition(index);
+         return instr->definitions[index];
       }
 
       aco_ptr<Instruction> get_ptr() const {
@@ -264,10 +264,10 @@ formats = [("pseudo", [Format.PSEUDO], 'Pseudo_instruction', list(itertools.prod
    {
       ${struct} *instr = create_instruction<${struct}>(opcode, (Format)(${'|'.join('(int)Format::%s' % f.name for f in formats)}), ${num_operands}, ${num_definitions});
         % for i in range(num_definitions):
-      instr->getDefinition(${i}) = def${i};
+            instr->definitions[${i}] = def${i};
         % endfor
         % for i in range(num_operands):
-      instr->getOperand(${i}) = op${i}.op;
+            instr->operands[${i}] = op${i}.op;
         % endfor
         % for f in formats:
             % for dest, field_name in zip(f.get_builder_field_dests(), f.get_builder_field_names()):

--- a/src/amd/compiler/aco_dead_code_analysis.cpp
+++ b/src/amd/compiler/aco_dead_code_analysis.cpp
@@ -55,19 +55,19 @@ void process_block(dce_ctx& ctx, Block& block)
          continue;
 
       aco_ptr<Instruction>& instr = block.instructions[idx];
-      bool is_live = instr->num_definitions == 0;
+      bool is_live = instr->definitions.size() == 0;
 
-      for (unsigned i = 0; !is_live && i < instr->num_definitions; i++) {
-         if (!instr->getDefinition(i).isTemp() || ctx.uses[instr->getDefinition(i).tempId()])
+      for (unsigned i = 0; !is_live && i < instr->definitions.size(); i++) {
+         if (!instr->definitions[i].isTemp() || ctx.uses[instr->definitions[i].tempId()])
             is_live = true;
       }
 
       if (is_live) {
-         for (unsigned i = 0; i < instr->num_operands; i++) {
-            if (instr->getOperand(i).isTemp()) {
-               if (ctx.uses[instr->getOperand(i).tempId()] == 0)
+         for (unsigned i = 0; i < instr->operands.size(); i++) {
+            if (instr->operands[i].isTemp()) {
+               if (ctx.uses[instr->operands[i].tempId()] == 0)
                   process_predecessors = true;
-               ctx.uses[instr->getOperand(i).tempId()]++;
+               ctx.uses[instr->operands[i].tempId()]++;
             }
          }
          live[idx] = true;
@@ -94,7 +94,7 @@ std::vector<uint16_t> dead_code_analysis(Program *program) {
    /* add one use to exec to prevent startpgm from being removed */
    aco_ptr<Instruction>& startpgm = program->blocks[0].instructions[0];
    assert(startpgm->opcode == aco_opcode::p_startpgm);
-   ctx.uses[startpgm->getDefinition(startpgm->num_definitions - 1).tempId()]++;
+   ctx.uses[startpgm->definitions.back().tempId()]++;
 
    return ctx.uses;
 }

--- a/src/amd/compiler/aco_dead_code_analysis.cpp
+++ b/src/amd/compiler/aco_dead_code_analysis.cpp
@@ -63,11 +63,11 @@ void process_block(dce_ctx& ctx, Block& block)
       }
 
       if (is_live) {
-         for (unsigned i = 0; i < instr->operands.size(); i++) {
-            if (instr->operands[i].isTemp()) {
-               if (ctx.uses[instr->operands[i].tempId()] == 0)
+         for (const Operand& op : instr->operands) {
+            if (op.isTemp()) {
+               if (ctx.uses[op.tempId()] == 0)
                   process_predecessors = true;
-               ctx.uses[instr->operands[i].tempId()]++;
+               ctx.uses[op.tempId()]++;
             }
          }
          live[idx] = true;

--- a/src/amd/compiler/aco_insert_NOPs.cpp
+++ b/src/amd/compiler/aco_insert_NOPs.cpp
@@ -68,7 +68,7 @@ int handle_instruction(NOP_ctx& ctx, aco_ptr<Instruction>& instr,
 
    /* break off from prevous SMEM clause if needed */
    if (instr->format == Format::SMEM && ctx.chip_class >= GFX8) {
-      bool is_store = instr->definitions.size() == 0;
+      const bool is_store = instr->definitions.empty();
       for (int pred_idx = new_idx - 1; pred_idx >= 0; pred_idx--) {
          aco_ptr<Instruction>& pred = new_instructions[pred_idx];
          if (pred->format != Format::SMEM)
@@ -76,7 +76,7 @@ int handle_instruction(NOP_ctx& ctx, aco_ptr<Instruction>& instr,
 
          /* Don't allow clauses with store instructions since the clause's
           * instructions may use the same address. */
-         if (is_store || pred->definitions.size() == 0)
+         if (is_store || pred->definitions.empty())
             return 1;
 
          Definition& instr_def = instr->definitions[0];

--- a/src/amd/compiler/aco_insert_exec_mask.cpp
+++ b/src/amd/compiler/aco_insert_exec_mask.cpp
@@ -102,10 +102,10 @@ bool pred_by_exec_mask(aco_ptr<Instruction>& instr) {
    if (instr->format == Format::PSEUDO) {
       switch (instr->opcode) {
       case aco_opcode::p_create_vector:
-         return instr->getDefinition(0).getTemp().type() == RegType::vgpr;
+         return instr->definitions[0].getTemp().type() == RegType::vgpr;
       case aco_opcode::p_extract_vector:
       case aco_opcode::p_split_vector:
-         return instr->getOperand(0).getTemp().type() == RegType::vgpr;
+         return instr->operands[0].getTemp().type() == RegType::vgpr;
       case aco_opcode::p_spill:
       case aco_opcode::p_reload:
          return false;
@@ -155,8 +155,8 @@ void mark_block_wqm(wqm_ctx &ctx, unsigned block_idx)
    aco_ptr<Instruction>& branch = block.instructions.back();
 
    if (branch->opcode != aco_opcode::p_branch) {
-      assert(branch->operandCount() && branch->getOperand(0).isTemp());
-      set_needs_wqm(ctx, branch->getOperand(0).getTemp());
+      assert(!branch->operands.empty() && branch->operands[0].isTemp());
+      set_needs_wqm(ctx, branch->operands[0].getTemp());
    }
 
    /* TODO: this sets more branch conditions to WQM than it needs to
@@ -195,10 +195,10 @@ void get_block_needs(wqm_ctx &ctx, block_info& info, Block* block)
       bool propagate_wqm = instr->opcode == aco_opcode::p_wqm;
       bool preserve_wqm = instr->opcode == aco_opcode::p_discard_if;
       bool pred_by_exec = pred_by_exec_mask(instr);
-      for (unsigned j = 0; j < instr->definitionCount(); j++) {
-         if (!instr->getDefinition(j).isTemp())
+      for (unsigned j = 0; j < instr->definitions.size(); j++) {
+         if (!instr->definitions[j].isTemp())
             continue;
-         unsigned def = instr->getDefinition(j).tempId();
+         unsigned def = instr->definitions[j].tempId();
          ctx.defined_in[def] = block->index;
          if (needs == Unspecified && ctx.needs_wqm[def]) {
             needs = pred_by_exec ? WQM : Unspecified;
@@ -207,10 +207,10 @@ void get_block_needs(wqm_ctx &ctx, block_info& info, Block* block)
       }
 
       if (propagate_wqm) {
-         for (unsigned j = 0; j < instr->operandCount(); j++) {
-            if (!instr->getOperand(j).isTemp())
+         for (unsigned j = 0; j < instr->operands.size(); j++) {
+            if (!instr->operands[j].isTemp())
                continue;
-            set_needs_wqm(ctx, instr->getOperand(j).getTemp());
+            set_needs_wqm(ctx, instr->operands[j].getTemp());
          }
       } else if (preserve_wqm && info.block_needs & WQM) {
          needs = Preserve_WQM;
@@ -327,7 +327,7 @@ unsigned add_coupling_code(exec_ctx& ctx, Block* block,
    if (idx == 0) {
       aco_ptr<Instruction>& startpgm = block->instructions[0];
       assert(startpgm->opcode == aco_opcode::p_startpgm);
-      Temp exec_mask = startpgm->getDefinition(startpgm->num_definitions - 1).getTemp();
+      Temp exec_mask = startpgm->definitions.back().getTemp();
       bld.insert(std::move(startpgm));
 
       if (ctx.handle_wqm) {
@@ -362,8 +362,8 @@ unsigned add_coupling_code(exec_ctx& ctx, Block* block,
          aco_ptr<Pseudo_instruction> phi;
          for (int i = 0; i < info.num_exec_masks - 1; i++) {
             phi.reset(create_instruction<Pseudo_instruction>(aco_opcode::p_linear_phi, Format::PSEUDO, preds.size(), 1));
-            phi->getDefinition(0) = bld.def(s2);
-            phi->getOperand(0) = Operand(ctx.info[preds[0]].exec[i].first);
+            phi->definitions[0] = bld.def(s2);
+            phi->operands[0] = Operand(ctx.info[preds[0]].exec[i].first);
             ctx.info[idx].exec[i].first = bld.insert(std::move(phi));
          }
       }
@@ -372,18 +372,18 @@ unsigned add_coupling_code(exec_ctx& ctx, Block* block,
       if (info.has_divergent_break) {
          /* this phi might be trivial but ensures a parallelcopy on the loop header */
          aco_ptr<Pseudo_instruction> phi{create_instruction<Pseudo_instruction>(aco_opcode::p_linear_phi, Format::PSEUDO, preds.size(), 1)};
-         phi->getDefinition(0) = bld.def(s2);
-         phi->getOperand(0) = Operand(ctx.info[preds[0]].exec[info.num_exec_masks - 1].first);
+         phi->definitions[0] = bld.def(s2);
+         phi->operands[0] = Operand(ctx.info[preds[0]].exec[info.num_exec_masks - 1].first);
          ctx.info[idx].exec.back().first = bld.insert(std::move(phi));
       }
 
       /* create ssa name for loop active mask */
       aco_ptr<Pseudo_instruction> phi{create_instruction<Pseudo_instruction>(aco_opcode::p_linear_phi, Format::PSEUDO, preds.size(), 1)};
       if (info.has_divergent_continue)
-         phi->getDefinition(0) = bld.def(s2);
+         phi->definitions[0] = bld.def(s2);
       else
-         phi->getDefinition(0) = bld.def(s2, exec);
-      phi->getOperand(0) = Operand(ctx.info[preds[0]].exec.back().first);
+         phi->definitions[0] = bld.def(s2, exec);
+      phi->operands[0] = Operand(ctx.info[preds[0]].exec.back().first);
       Temp loop_active = bld.insert(std::move(phi));
 
       if (info.has_divergent_break) {
@@ -424,21 +424,21 @@ unsigned add_coupling_code(exec_ctx& ctx, Block* block,
          while (k < info.num_exec_masks - 1) {
             aco_ptr<Instruction>& phi = header->instructions[k];
             assert(phi->opcode == aco_opcode::p_linear_phi);
-            for (unsigned i = 1; i < phi->num_operands; i++)
-               phi->getOperand(i) = Operand(ctx.info[header_preds[i]].exec[k].first);
+            for (unsigned i = 1; i < phi->operands.size(); i++)
+               phi->operands[i] = Operand(ctx.info[header_preds[i]].exec[k].first);
             k++;
          }
       }
       aco_ptr<Instruction>& phi = header->instructions[k++];
       assert(phi->opcode == aco_opcode::p_linear_phi);
-      for (unsigned i = 1; i < phi->num_operands; i++)
-         phi->getOperand(i) = Operand(ctx.info[header_preds[i]].exec[info.num_exec_masks - 1].first);
+      for (unsigned i = 1; i < phi->operands.size(); i++)
+         phi->operands[i] = Operand(ctx.info[header_preds[i]].exec[info.num_exec_masks - 1].first);
 
       if (info.has_divergent_break) {
          aco_ptr<Instruction>& phi = header->instructions[k];
          assert(phi->opcode == aco_opcode::p_linear_phi);
-         for (unsigned i = 1; i < phi->num_operands; i++)
-            phi->getOperand(i) = Operand(ctx.info[header_preds[i]].exec[info.num_exec_masks].first);
+         for (unsigned i = 1; i < phi->operands.size(); i++)
+            phi->operands[i] = Operand(ctx.info[header_preds[i]].exec[info.num_exec_masks].first);
       }
 
       assert(!(block->kind & block_kind_top_level) || info.num_exec_masks <= 2);
@@ -459,9 +459,9 @@ unsigned add_coupling_code(exec_ctx& ctx, Block* block,
          } else {
             /* create phi for loop footer */
             aco_ptr<Pseudo_instruction> phi{create_instruction<Pseudo_instruction>(aco_opcode::p_linear_phi, Format::PSEUDO, preds.size(), 1)};
-            phi->getDefinition(0) = bld.def(s2);
-            for (unsigned i = 0; i < phi->num_operands; i++)
-               phi->getOperand(i) = Operand(ctx.info[preds[i]].exec[k].first);
+            phi->definitions[0] = bld.def(s2);
+            for (unsigned i = 0; i < phi->operands.size(); i++)
+               phi->operands[i] = Operand(ctx.info[preds[i]].exec[k].first);
             ctx.info[idx].exec.emplace_back(bld.insert(std::move(phi)), type);
          }
       }
@@ -557,7 +557,7 @@ unsigned add_coupling_code(exec_ctx& ctx, Block* block,
 
 void lower_fs_buffer_store_smem(Builder& bld, bool need_check, aco_ptr<Instruction>& instr, Temp cur_exec)
 {
-   Operand offset = instr->getOperand(1);
+   Operand offset = instr->operands[1];
    if (need_check) {
       /* if exec is zero, then use UINT32_MAX as an offset and make this store a no-op */
       Temp nonempty = bld.sopc(aco_opcode::s_cmp_lg_u64, bld.def(s1, scc), cur_exec, Operand(0u));
@@ -573,7 +573,7 @@ void lower_fs_buffer_store_smem(Builder& bld, bool need_check, aco_ptr<Instructi
    if (!offset.isConstant())
       offset.setFixed(m0);
 
-   switch (instr->getOperand(2).size()) {
+   switch (instr->operands[2].size()) {
    case 1:
       instr->opcode = aco_opcode::s_buffer_store_dword;
       break;
@@ -586,10 +586,10 @@ void lower_fs_buffer_store_smem(Builder& bld, bool need_check, aco_ptr<Instructi
    default:
       unreachable("Invalid SMEM buffer store size");
    }
-   instr->getOperand(1) = offset;
+   instr->operands[1] = offset;
    /* as_uniform() needs to be done here so it's done in exact mode and helper
     * lanes don't contribute. */
-   instr->getOperand(2) = Operand(bld.as_uniform(instr->getOperand(2)));
+   instr->operands[2] = Operand(bld.as_uniform(instr->operands[2]));
 }
 
 void process_instructions(exec_ctx& ctx, Block* block,
@@ -633,20 +633,20 @@ void process_instructions(exec_ctx& ctx, Block* block,
          }
          unsigned num = ctx.info[block->index].exec.size();
          assert(num);
-         Operand cond = instr->getOperand(0);
+         Operand cond = instr->operands[0];
          instr.reset(create_instruction<Pseudo_instruction>(aco_opcode::p_discard_if, Format::PSEUDO, num + 1, num + 1));
          for (unsigned i = 0; i < num; i++) {
-            instr->getOperand(i) = Operand(ctx.info[block->index].exec[i].first);
+            instr->operands[i] = Operand(ctx.info[block->index].exec[i].first);
             if (i == num - 1)
-               instr->getOperand(i).setFixed(exec);
+               instr->operands[i].setFixed(exec);
             Temp new_mask = bld.tmp(s2);
-            instr->getDefinition(i) = Definition(new_mask);
+            instr->definitions[i] = Definition(new_mask);
             ctx.info[block->index].exec[i].first = new_mask;
          }
          assert((ctx.info[block->index].exec[0].second & mask_type_wqm) == 0);
-         instr->getDefinition(num - 1).setFixed(exec);
-         instr->getOperand(num) = cond;
-         instr->getDefinition(num) = bld.def(s1, scc);
+         instr->definitions[num - 1].setFixed(exec);
+         instr->operands[num] = cond;
+         instr->definitions[num] = bld.def(s1, scc);
 
       } else if (needs == WQM && state != WQM) {
          transition_to_WQM(ctx, bld, block->index);
@@ -657,11 +657,11 @@ void process_instructions(exec_ctx& ctx, Block* block,
       }
 
       if (instr->opcode == aco_opcode::p_is_helper || instr->opcode == aco_opcode::p_load_helper) {
-         Definition dst = instr->getDefinition(0);
+         Definition dst = instr->definitions[0];
          if (state == Exact) {
             instr.reset(create_instruction<SOP1_instruction>(aco_opcode::s_mov_b64, Format::SOP1, 1, 1));
-            instr->getOperand(0) = Operand(0u);
-            instr->getDefinition(0) = dst;
+            instr->operands[0] = Operand(0u);
+            instr->definitions[0] = dst;
          } else {
             std::pair<Temp, uint8_t>& exact_mask = ctx.info[block->index].exec[0];
             if (instr->opcode == aco_opcode::p_load_helper &&
@@ -680,10 +680,10 @@ void process_instructions(exec_ctx& ctx, Block* block,
             assert(exact_mask.second & mask_type_exact);
 
             instr.reset(create_instruction<SOP2_instruction>(aco_opcode::s_andn2_b64, Format::SOP2, 2, 2));
-            instr->getOperand(0) = Operand(ctx.info[block->index].exec.back().first); /* current exec */
-            instr->getOperand(1) = Operand(exact_mask.first);
-            instr->getDefinition(0) = dst;
-            instr->getDefinition(1) = bld.def(s1, scc);
+            instr->operands[0] = Operand(ctx.info[block->index].exec.back().first); /* current exec */
+            instr->operands[1] = Operand(exact_mask.first);
+            instr->definitions[0] = dst;
+            instr->definitions[1] = bld.def(s1, scc);
          }
       } else if (instr->opcode == aco_opcode::p_demote_to_helper) {
          /* turn demote into discard_if with only exact masks */
@@ -692,7 +692,7 @@ void process_instructions(exec_ctx& ctx, Block* block,
 
          int num = 0;
          Temp cond;
-         if (instr->num_operands == 0) {
+         if (instr->operands.empty()) {
             /* transition to exact and set exec to zero */
             Temp old_exec = ctx.info[block->index].exec.back().first;
             Temp new_exec = bld.tmp(s2);
@@ -707,8 +707,8 @@ void process_instructions(exec_ctx& ctx, Block* block,
          } else {
             /* demote_if: transition to exact */
             transition_to_Exact(ctx, bld, block->index);
-            assert(instr->getOperand(0).isTemp());
-            cond = instr->getOperand(0).getTemp();
+            assert(instr->operands[0].isTemp());
+            cond = instr->operands[0].getTemp();
             num = 1;
          }
 
@@ -718,18 +718,18 @@ void process_instructions(exec_ctx& ctx, Block* block,
          int k = 0;
          for (unsigned i = 0; k < num; i++) {
             if (ctx.info[block->index].exec[i].second & mask_type_exact) {
-               instr->getOperand(k) = Operand(ctx.info[block->index].exec[i].first);
+               instr->operands[k] = Operand(ctx.info[block->index].exec[i].first);
                Temp new_mask = bld.tmp(s2);
-               instr->getDefinition(k) = Definition(new_mask);
+               instr->definitions[k] = Definition(new_mask);
                if (i == ctx.info[block->index].exec.size() - 1)
-                  instr->getDefinition(k).setFixed(exec);
+                  instr->definitions[k].setFixed(exec);
                k++;
                ctx.info[block->index].exec[i].first = new_mask;
             }
          }
          assert(k == num);
-         instr->getDefinition(num) = bld.def(s1, scc);
-         instr->getOperand(num) = Operand(cond);
+         instr->definitions[num] = bld.def(s1, scc);
+         instr->operands[num] = Operand(cond);
          state = Exact;
 
       } else if (instr->opcode == aco_opcode::p_fs_buffer_store_smem) {
@@ -853,14 +853,14 @@ void add_branch_code(exec_ctx& ctx, Block* block)
 
       aco_ptr<Pseudo_instruction> discard{create_instruction<Pseudo_instruction>(aco_opcode::p_discard_if, Format::PSEUDO, num + 1, num + 1)};
       for (unsigned i = 0; i < num; i++) {
-         discard->getOperand(i) = Operand(ctx.info[block->index].exec[i].first);
+         discard->operands[i] = Operand(ctx.info[block->index].exec[i].first);
          Temp new_mask = bld.tmp(s2);
-         discard->getDefinition(i) = Definition(new_mask);
+         discard->definitions[i] = Definition(new_mask);
          ctx.info[block->index].exec[i].first = new_mask;
       }
       assert(!ctx.handle_wqm || (ctx.info[block->index].exec[0].second & mask_type_wqm) == 0);
-      discard->getOperand(num) = Operand(cond);
-      discard->getDefinition(num) = bld.def(s1, scc);
+      discard->operands[num] = Operand(cond);
+      discard->definitions[num] = bld.def(s1, scc);
 
       bld.insert(std::move(discard));
       if ((block->kind & (block_kind_break | block_kind_uniform)) == block_kind_break)
@@ -920,7 +920,7 @@ void add_branch_code(exec_ctx& ctx, Block* block)
       // orig = s_and_saveexec_b64
       assert(block->linear_succs.size() == 2);
       assert(block->instructions.back()->opcode == aco_opcode::p_cbranch_z);
-      Temp cond = block->instructions.back()->getOperand(0).getTemp();
+      Temp cond = block->instructions.back()->operands[0].getTemp();
       block->instructions.pop_back();
       Temp current_exec = ctx.info[idx].exec.back().first;
       uint8_t mask_type = ctx.info[idx].exec.back().second & (mask_type_wqm | mask_type_exact);

--- a/src/amd/compiler/aco_insert_exec_mask.cpp
+++ b/src/amd/compiler/aco_insert_exec_mask.cpp
@@ -207,10 +207,10 @@ void get_block_needs(wqm_ctx &ctx, block_info& info, Block* block)
       }
 
       if (propagate_wqm) {
-         for (unsigned j = 0; j < instr->operands.size(); j++) {
-            if (!instr->operands[j].isTemp())
-               continue;
-            set_needs_wqm(ctx, instr->operands[j].getTemp());
+         for (const Operand& op : instr->operands) {
+            if (op.isTemp()) {
+               set_needs_wqm(ctx, op.getTemp());
+            }
          }
       } else if (preserve_wqm && info.block_needs & WQM) {
          needs = Preserve_WQM;

--- a/src/amd/compiler/aco_insert_exec_mask.cpp
+++ b/src/amd/compiler/aco_insert_exec_mask.cpp
@@ -195,10 +195,10 @@ void get_block_needs(wqm_ctx &ctx, block_info& info, Block* block)
       bool propagate_wqm = instr->opcode == aco_opcode::p_wqm;
       bool preserve_wqm = instr->opcode == aco_opcode::p_discard_if;
       bool pred_by_exec = pred_by_exec_mask(instr);
-      for (unsigned j = 0; j < instr->definitions.size(); j++) {
-         if (!instr->definitions[j].isTemp())
+      for (const Definition& definition : instr->definitions) {
+         if (!definition.isTemp())
             continue;
-         unsigned def = instr->definitions[j].tempId();
+         const unsigned def = definition.tempId();
          ctx.defined_in[def] = block->index;
          if (needs == Unspecified && ctx.needs_wqm[def]) {
             needs = pred_by_exec ? WQM : Unspecified;

--- a/src/amd/compiler/aco_instruction_selection_setup.cpp
+++ b/src/amd/compiler/aco_instruction_selection_setup.cpp
@@ -1074,11 +1074,11 @@ void add_startpgm(struct isel_context *ctx)
    for (unsigned i = 0; i < args.count; i++) {
       if (args.assign[i]) {
          *args.assign[i] = Temp{ctx->program->allocateId(), args.types[i]};
-         startpgm->getDefinition(i) = Definition(*args.assign[i]);
-         startpgm->getDefinition(i).setFixed(args.reg[i]);
+         startpgm->definitions[i] = Definition(*args.assign[i]);
+         startpgm->definitions[i].setFixed(args.reg[i]);
       }
    }
-   startpgm->getDefinition(args.count) = Definition{ctx->program->allocateId(), exec, s2};
+   startpgm->definitions[args.count] = Definition{ctx->program->allocateId(), exec, s2};
    ctx->block->instructions.push_back(std::move(startpgm));
 }
 

--- a/src/amd/compiler/aco_ir.h
+++ b/src/amd/compiler/aco_ir.h
@@ -48,7 +48,7 @@ namespace aco {
  * - VOP2* | VOP3A represents a VOP2 instruction in VOP3A encoding
  * - VOP2* | DPP represents a VOP2 instruction with data parallel primitive.
  * - VOP2* | SDWA represents a VOP2 instruction with sub-dword addressing.
- * 
+ *
  * (*) The same is applicable for VOP1 and VOPC instructions.
  */
 enum class Format : std::uint16_t {
@@ -137,9 +137,9 @@ struct RegClass {
    };
 
    RegClass() = default;
-   constexpr RegClass(RC rc) 
+   constexpr RegClass(RC rc)
       : rc(rc) {}
-   constexpr RegClass(RegType type, unsigned size) 
+   constexpr RegClass(RegType type, unsigned size)
       : rc((RC) ((type == RegType::vgpr ? 1 << 5 : 0) | size)) {}
 
    constexpr operator RC() const { return rc; }
@@ -457,7 +457,7 @@ public:
       return tempId() > 0;
    }
 
-   Temp getTemp() noexcept
+   Temp getTemp() const noexcept
    {
       return temp;
    }

--- a/src/amd/compiler/aco_ir.h
+++ b/src/amd/compiler/aco_ir.h
@@ -34,6 +34,7 @@
 #include "ac_binary.h"
 #include "amd_family.h"
 #include "aco_opcodes.h"
+#include "aco_util.h"
 
 
 struct radv_shader_variant_info;
@@ -539,17 +540,8 @@ struct Instruction {
    aco_opcode opcode;
    Format format;
 
-   Operand *operands;
-   uint32_t num_operands;
-
-   Definition *definitions;
-   uint32_t num_definitions;
-
-   // TODO remove
-   uint32_t definitionCount() const { return num_definitions; }
-   uint32_t operandCount() const { return num_operands; }
-   Operand& getOperand(int index) { return operands[index]; }
-   Definition& getDefinition(int index) { return definitions[index]; }
+   aco::span<Operand> operands;
+   aco::span<Definition> definitions;
 
    bool isVALU()
    {
@@ -846,11 +838,9 @@ T* create_instruction(aco_opcode opcode, Format format, uint32_t num_operands, u
 
    inst->opcode = opcode;
    inst->format = format;
-   inst->num_operands = num_operands;
-   inst->num_definitions = num_definitions;
 
-   inst->operands = (Operand*)(data + sizeof(T));
-   inst->definitions = (Definition*)(data + sizeof(T) + num_operands * sizeof(Operand));
+   inst->operands = aco::span<Operand>((Operand*)(data + sizeof(T)), num_operands);
+   inst->definitions = aco::span<Definition>((Definition*)inst->operands.end(), num_definitions);
 
    return inst;
 }

--- a/src/amd/compiler/aco_live_var_analysis.cpp
+++ b/src/amd/compiler/aco_live_var_analysis.cpp
@@ -79,9 +79,9 @@ void process_live_temps_per_block(Program *program, live& lives, Block* block,
 
       Instruction *insn = block->instructions[idx].get();
       /* KILL */
-      for (unsigned i = 0; i < insn->definitionCount(); ++i)
+      for (unsigned i = 0; i < insn->definitions.size(); ++i)
       {
-         Definition &definition = insn->getDefinition(i);
+         Definition &definition = insn->definitions[i];
          if (!definition.isTemp()) {
             continue;
          }
@@ -114,7 +114,7 @@ void process_live_temps_per_block(Program *program, live& lives, Block* block,
                                       : block->linear_preds;
          for (unsigned i = 0; i < preds.size(); ++i)
          {
-            Operand &operand = insn->getOperand(i);
+            Operand &operand = insn->operands[i];
             if (!operand.isTemp()) {
                continue;
             }
@@ -130,9 +130,9 @@ void process_live_temps_per_block(Program *program, live& lives, Block* block,
       } else if (insn->opcode == aco_opcode::p_logical_end) {
          new_demand.sgpr += phi_sgpr_ops[block->index];
       } else {
-         for (unsigned i = 0; i < insn->operandCount(); ++i)
+         for (unsigned i = 0; i < insn->operands.size(); ++i)
          {
-            Operand& operand = insn->getOperand(i);
+            Operand& operand = insn->operands[i];
             if (!operand.isTemp()) {
                continue;
             }
@@ -142,10 +142,10 @@ void process_live_temps_per_block(Program *program, live& lives, Block* block,
                                 : live_vgprs.insert(temp).second;
             if (inserted) {
                operand.setFirstKill(true);
-               for (unsigned j = i + 1; j < insn->operandCount(); ++j) {
-                  if (insn->getOperand(j).isTemp() && insn->getOperand(j).tempId() == operand.tempId()) {
-                     insn->getOperand(j).setFirstKill(false);
-                     insn->getOperand(j).setKill(true);
+               for (unsigned j = i + 1; j < insn->operands.size(); ++j) {
+                  if (insn->operands[j].isTemp() && insn->operands[j].tempId() == operand.tempId()) {
+                     insn->operands[j].setFirstKill(false);
+                     insn->operands[j].setKill(true);
                   }
                }
                new_demand += temp;

--- a/src/amd/compiler/aco_live_var_analysis.cpp
+++ b/src/amd/compiler/aco_live_var_analysis.cpp
@@ -79,9 +79,7 @@ void process_live_temps_per_block(Program *program, live& lives, Block* block,
 
       Instruction *insn = block->instructions[idx].get();
       /* KILL */
-      for (unsigned i = 0; i < insn->definitions.size(); ++i)
-      {
-         Definition &definition = insn->definitions[i];
+      for (Definition& definition : insn->definitions) {
          if (!definition.isTemp()) {
             continue;
          }

--- a/src/amd/compiler/aco_lower_to_hw_instr.cpp
+++ b/src/amd/compiler/aco_lower_to_hw_instr.cpp
@@ -546,25 +546,24 @@ void lower_to_hw_instr(Program* program)
                std::map<PhysReg, copy_operation> copy_operations;
                RegClass rc_def = RegClass(instr->definitions[0].getTemp().type(), 1);
                unsigned reg_idx = 0;
-               for (unsigned i = 0; i < instr->operands.size(); i++)
-               {
-                  if (instr->operands[i].isUndefined())
+               for (const Operand& op : instr->operands) {
+                  if (op.isUndefined())
                      continue;
 
-                  if (instr->operands[i].isConstant()) {
-                     PhysReg reg = PhysReg{instr->definitions[0].physReg() + reg_idx};
-                     Definition def = Definition(reg, rc_def);
-                     copy_operations[reg] = {instr->operands[i], def, 0, 1};
+                  if (op.isConstant()) {
+                     const PhysReg reg = PhysReg{instr->definitions[0].physReg() + reg_idx};
+                     const Definition def = Definition(reg, rc_def);
+                     copy_operations[reg] = {op, def, 0, 1};
                      reg_idx++;
                      continue;
                   }
 
-                  RegClass rc_op = RegClass(instr->operands[i].getTemp().type(), 1);
-                  for (unsigned j = 0; j < instr->operands[i].size(); j++)
+                  RegClass rc_op = RegClass(op.getTemp().type(), 1);
+                  for (unsigned j = 0; j < op.size(); j++)
                   {
-                     Operand op = Operand(PhysReg{instr->operands[i].physReg() + j}, rc_op);
-                     Definition def = Definition(PhysReg{instr->definitions[0].physReg() + reg_idx}, rc_def);
-                     copy_operations[def.physReg()] = {op, def, 0, 1};
+                     const Operand copy_op = Operand(PhysReg{op.physReg() + j}, rc_op);
+                     const Definition def = Definition(PhysReg{instr->definitions[0].physReg() + reg_idx}, rc_def);
+                     copy_operations[def.physReg()] = {copy_op, def, 0, 1};
                      reg_idx++;
                   }
                }

--- a/src/amd/compiler/aco_opt_value_numbering.cpp
+++ b/src/amd/compiler/aco_opt_value_numbering.cpp
@@ -241,7 +241,7 @@ void process_block(Block& block,
             op.setTemp(it->second);
       }
 
-      if (!instr->definitions.size() || !run) {
+      if (instr->definitions.empty() || !run) {
          if (instr->opcode == aco_opcode::p_logical_start)
             run = true;
          else if (instr->opcode == aco_opcode::p_logical_end)

--- a/src/amd/compiler/aco_opt_value_numbering.cpp
+++ b/src/amd/compiler/aco_opt_value_numbering.cpp
@@ -233,12 +233,12 @@ void process_block(Block& block,
    while (it != block.instructions.end()) {
       aco_ptr<Instruction>& instr = *it;
       /* first, rename operands */
-      for (unsigned i = 0; i < instr->operands.size(); i++) {
-         if (!instr->operands[i].isTemp())
+      for (Operand& op : instr->operands) {
+         if (!op.isTemp())
             continue;
-         std::map<uint32_t, Temp>::iterator it = renames.find(instr->operands[i].tempId());
+         auto it = renames.find(op.tempId());
          if (it != renames.end())
-            instr->operands[i].setTemp(it->second);
+            op.setTemp(it->second);
       }
 
       if (!instr->definitions.size() || !run) {
@@ -292,12 +292,12 @@ void rename_phi_operands(Block& block, std::map<uint32_t, Temp>& renames)
       if (phi->opcode != aco_opcode::p_phi && phi->opcode != aco_opcode::p_linear_phi)
          break;
 
-      for (unsigned i = 0; i < phi->operands.size(); i++) {
-         if (!phi->operands[i].isTemp())
+      for (Operand& op : phi->operands) {
+         if (!op.isTemp())
             continue;
-         std::map<uint32_t, Temp>::iterator it = renames.find(phi->operands[i].tempId());
+         auto it = renames.find(op.tempId());
          if (it != renames.end())
-            phi->operands[i].setTemp(it->second);
+            op.setTemp(it->second);
       }
    }
 }

--- a/src/amd/compiler/aco_print_ir.cpp
+++ b/src/amd/compiler/aco_print_ir.cpp
@@ -419,7 +419,7 @@ void aco_print_instr_format_specific(struct Instruction *instr, FILE *output)
 
 void aco_print_instr(struct Instruction *instr, FILE *output)
 {
-   if (instr->definitions.size()) {
+   if (!instr->definitions.empty()) {
       for (unsigned i = 0; i < instr->definitions.size(); ++i) {
          aco_print_definition(&instr->definitions[i], output);
          if (i + 1 != instr->definitions.size())

--- a/src/amd/compiler/aco_print_ir.cpp
+++ b/src/amd/compiler/aco_print_ir.cpp
@@ -218,8 +218,8 @@ void aco_print_instr_format_specific(struct Instruction *instr, FILE *output)
    }
    case Format::MIMG: {
       MIMG_instruction* mimg = static_cast<MIMG_instruction*>(instr);
-      unsigned identity_dmask = instr->num_definitions ?
-                                (1 << instr->getDefinition(0).size()) - 1 :
+      unsigned identity_dmask = !instr->definitions.empty() ?
+                                (1 << instr->definitions[0].size()) - 1 :
                                 0xf;
       if ((mimg->dmask & identity_dmask) != identity_dmask)
          fprintf(output, " dmask:%s%s%s%s",
@@ -419,38 +419,38 @@ void aco_print_instr_format_specific(struct Instruction *instr, FILE *output)
 
 void aco_print_instr(struct Instruction *instr, FILE *output)
 {
-   if (instr->definitionCount()) {
-      for (unsigned i = 0; i < instr->definitionCount(); ++i) {
-         aco_print_definition(&instr->getDefinition(i), output);
-         if (i + 1 != instr->definitionCount())
+   if (instr->definitions.size()) {
+      for (unsigned i = 0; i < instr->definitions.size(); ++i) {
+         aco_print_definition(&instr->definitions[i], output);
+         if (i + 1 != instr->definitions.size())
             fprintf(output, ", ");
       }
       fprintf(output, " = ");
    }
    fprintf(output, "%s", instr_info.name[(int)instr->opcode]);
-   if (instr->operandCount()) {
-      bool abs[instr->num_operands];
-      bool neg[instr->num_operands];
+   if (instr->operands.size()) {
+      bool abs[instr->operands.size()];
+      bool neg[instr->operands.size()];
       if ((int)instr->format & (int)Format::VOP3A) {
          VOP3A_instruction* vop3 = static_cast<VOP3A_instruction*>(instr);
-         for (unsigned i = 0; i < instr->operandCount(); ++i) {
+         for (unsigned i = 0; i < instr->operands.size(); ++i) {
             abs[i] = vop3->abs[i];
             neg[i] = vop3->neg[i];
          }
       } else if (instr->isDPP()) {
          DPP_instruction* dpp = static_cast<DPP_instruction*>(instr);
-         assert(instr->operandCount() <= 2);
-         for (unsigned i = 0; i < instr->operandCount(); ++i) {
+         assert(instr->operands.size() <= 2);
+         for (unsigned i = 0; i < instr->operands.size(); ++i) {
             abs[i] = dpp->abs[i];
             neg[i] = dpp->neg[i];
          }
       } else {
-         for (unsigned i = 0; i < instr->operandCount(); ++i) {
+         for (unsigned i = 0; i < instr->operands.size(); ++i) {
             abs[i] = false;
             neg[i] = false;
          }
       }
-      for (unsigned i = 0; i < instr->operandCount(); ++i) {
+      for (unsigned i = 0; i < instr->operands.size(); ++i) {
          if (i)
             fprintf(output, ", ");
          else
@@ -460,7 +460,7 @@ void aco_print_instr(struct Instruction *instr, FILE *output)
             fprintf(output, "-");
          if (abs[i])
             fprintf(output, "|");
-         aco_print_operand(&instr->getOperand(i), output);
+         aco_print_operand(&instr->operands[i], output);
          if (abs[i])
             fprintf(output, "|");
        }

--- a/src/amd/compiler/aco_spill.cpp
+++ b/src/amd/compiler/aco_spill.cpp
@@ -127,9 +127,9 @@ void next_uses_per_block(spill_ctx& ctx, unsigned block_idx, std::set<uint32_t>&
           instr->opcode == aco_opcode::p_phi)
          break;
 
-      for (unsigned i = 0; i < instr->definitions.size(); i++) {
-         if (instr->definitions[i].isTemp())
-            next_uses.erase(instr->definitions[i].getTemp());
+      for (const Definition& def : instr->definitions) {
+         if (def.isTemp())
+            next_uses.erase(def.getTemp());
       }
 
       for (const Operand& op : instr->operands) {
@@ -268,9 +268,9 @@ void get_rematerialize_info(spill_ctx& ctx)
          else if (instr->opcode == aco_opcode::p_logical_end)
             logical = false;
          if (logical && should_rematerialize(instr)) {
-            for (unsigned i = 0; i < instr->definitions.size(); i++) {
-               if (instr->definitions[i].isTemp()) {
-                  ctx.remat[instr->definitions[i].getTemp()] = (remat_info){instr.get()};
+            for (const Definition& def : instr->definitions) {
+               if (def.isTemp()) {
+                  ctx.remat[def.getTemp()] = (remat_info){instr.get()};
                   ctx.remat_use_count[instr.get()] = 0;
                }
             }
@@ -305,9 +305,9 @@ std::vector<std::map<Temp, uint32_t>> local_next_uses(spill_ctx& ctx, Block* blo
          if (op.isTemp())
             next_uses[op.getTemp()] = idx;
       }
-      for (unsigned i = 0; i < instr->definitions.size(); i++) {
-         if (instr->definitions[i].isTemp())
-            next_uses.erase(instr->definitions[i].getTemp());
+      for (const Definition& def : instr->definitions) {
+         if (def.isTemp())
+            next_uses.erase(def.getTemp());
       }
       local_next_uses[idx] = next_uses;
    }
@@ -560,9 +560,9 @@ RegisterDemand init_live_in_vars(spill_ctx& ctx, Block* block, unsigned block_id
    /* if reg pressure at first instruction is still too high, add partially spilled variables */
    RegisterDemand reg_pressure;
    if (idx == 0) {
-      for (unsigned i = 0; i < block->instructions[idx]->definitions.size(); i++) {
-         if (block->instructions[idx]->definitions[i].isTemp()) {
-            reg_pressure -= block->instructions[idx]->definitions[i].getTemp();
+      for (const Definition& def : block->instructions[idx]->definitions) {
+         if (def.isTemp()) {
+            reg_pressure -= def.getTemp();
          }
       }
       for (const Operand& op : block->instructions[idx]->operands) {
@@ -1034,10 +1034,10 @@ void process_block(spill_ctx& ctx, unsigned block_idx, Block* block,
 
          RegisterDemand new_demand = ctx.register_demand[block_idx][idx];
          if (idx == 0) {
-            for (unsigned i = 0; i < instr->definitions.size(); i++) {
-               if (!instr->definitions[i].isTemp())
+            for (const Definition& def : instr->definitions) {
+               if (!def.isTemp())
                   continue;
-               new_demand += instr->definitions[i].getTemp();
+               new_demand += def.getTemp();
             }
          } else {
             new_demand.update(ctx.register_demand[block_idx][idx - 1]);

--- a/src/amd/compiler/aco_util.h
+++ b/src/amd/compiler/aco_util.h
@@ -1,0 +1,233 @@
+/*
+ * Copyright Michael Schellenberger Costa
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the next
+ * paragraph) shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ */
+
+#ifndef ACO_UTIL_H
+#define ACO_UTIL_H
+
+#include <cassert>
+#include <iterator>
+
+namespace aco {
+
+/*! \brief      Definition of a span object
+*
+*   \details    A "span" is an "array view" type for holding a view of contiguous
+*               data. The "span" object does not own the data itself.
+*/
+template <typename T>
+class span {
+public:
+   using value_type             = T;
+   using pointer                = value_type*;
+   using const_pointer          = const value_type*;
+   using reference              = value_type&;
+   using const_reference        = const value_type&;
+   using iterator               = pointer;
+   using const_iterator         = const_pointer;
+   using reverse_iterator       = std::reverse_iterator<iterator>;
+   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+   using size_type              = std::size_t;
+   using difference_type        = std::ptrdiff_t;
+
+   /*! \brief                  Compiler generated default constructor
+   */
+   constexpr span() = default;
+
+   /*! \brief                 Constructor taking a pointer and the length of the span
+   *   \param[in]   data      Pointer to the underlying data array
+   *   \param[in]   length    The size of the span
+   */
+   constexpr span(pointer data, const size_type length)
+       : data{ data } , length{ length } {}
+
+   /*! \brief                 Returns an iterator to the begin of the span
+   *   \return                data
+   */
+   iterator begin() noexcept {
+      return data;
+   }
+
+   /*! \brief                 Returns a const_iterator to the begin of the span
+   *   \return                data
+   */
+   const_iterator begin() const noexcept {
+      return data;
+   }
+
+   /*! \brief                 Returns an iterator to the end of the span
+   *   \return                data + length
+   */
+   iterator end() noexcept {
+      return std::next(data, length);
+   }
+
+   /*! \brief                 Returns a const_iterator to the end of the span
+   *   \return                data + length
+   */
+   const_iterator end() const noexcept {
+      return std::next(data, length);
+   }
+
+   /*! \brief                 Returns a const_iterator to the begin of the span
+   *   \return                data
+   */
+   const_iterator cbegin() const noexcept {
+      return data;
+   }
+
+   /*! \brief                 Returns a const_iterator to the end of the span
+   *   \return                data + length
+   */
+   const_iterator cend() const noexcept {
+      return std::next(data, length);
+   }
+
+   /*! \brief                 Returns a reverse_iterator to the end of the span
+   *   \return                reverse_iterator(end())
+   */
+   reverse_iterator rbegin() noexcept {
+      return reverse_iterator(end());
+   }
+
+   /*! \brief                 Returns a const_reverse_iterator to the end of the span
+   *   \return                reverse_iterator(end())
+   */
+   const_reverse_iterator rbegin() const noexcept {
+      return const_reverse_iterator(end());
+   }
+
+   /*! \brief                 Returns a reverse_iterator to the begin of the span
+   *   \return                reverse_iterator(begin())
+   */
+   reverse_iterator rend() noexcept {
+      return reverse_iterator(begin());
+   }
+
+   /*! \brief                 Returns a const_reverse_iterator to the begin of the span
+   *   \return                reverse_iterator(begin())
+   */
+   const_reverse_iterator rend() const noexcept {
+      return const_reverse_iterator(begin());
+   }
+
+   /*! \brief                 Returns a const_reverse_iterator to the end of the span
+   *   \return                rbegin()
+   */
+   const_reverse_iterator crbegin() const noexcept {
+      return const_reverse_iterator(cend());
+   }
+
+   /*! \brief                 Returns a const_reverse_iterator to the begin of the span
+   *   \return                rend()
+   */
+   const_reverse_iterator crend() const noexcept {
+      return const_reverse_iterator(cbegin());
+   }
+
+   /*! \brief                 Unchecked access operator
+   *   \param[in] index       Index of the element we want to access
+   *   \return                *(std::next(data, index))
+   */
+   reference operator[](const size_type index) noexcept {
+      assert(length > index);
+      return *(std::next(data, index));
+   }
+
+   /*! \brief                 Unchecked const access operator
+   *   \param[in] index       Index of the element we want to access
+   *   \return                *(std::next(data, index))
+   */
+   const_reference operator[](const size_type index) const noexcept {
+      assert(length > index);
+      return *(std::next(data, index));
+   }
+
+   /*! \brief                 Returns a reference to the last element of the span
+   *   \return                *(std::next(data, length - 1))
+   */
+   reference back() noexcept {
+      assert(length > 0);
+      return *(std::next(data, length - 1));
+   }
+
+   /*! \brief                 Returns a const_reference to the last element of the span
+   *   \return                *(std::next(data, length - 1))
+   */
+   const_reference back() const noexcept {
+      assert(length > 0);
+      return *(std::next(data, length - 1));
+   }
+
+   /*! \brief                 Returns a reference to the first element of the span
+   *   \return                *begin()
+   */
+   reference front() noexcept {
+      assert(length > 0);
+      return *begin();
+   }
+
+   /*! \brief                 Returns a const_reference to the first element of the span
+   *   \return                *cbegin()
+   */
+   const_reference front() const noexcept {
+      assert(length > 0);
+      return *cbegin();
+   }
+
+   /*! \brief                 Returns true if the span is empty
+   *   \return                length == 0
+   */
+   constexpr bool empty() const noexcept {
+      return length == 0;
+   }
+
+   /*! \brief                 Returns the size of the span
+   *   \return                length == 0
+   */
+   constexpr size_type size() const noexcept {
+      return length;
+   }
+
+   /*! \brief                 Decreases the size of the span by 1
+   */
+   void pop_back() noexcept {
+      assert(length > 0);
+      --length;
+   }
+
+   /*! \brief                 Clears the span
+   */
+   void clear() noexcept {
+      data = nullptr;
+      length = 0;
+   }
+
+private:
+   pointer data{ nullptr };   //!> Pointer to the underlying data array
+   size_type length{ 0 };     //!> Size of the span
+};
+
+} // namespace aco
+
+#endif // ACO_UTIL_H

--- a/src/amd/compiler/meson.build
+++ b/src/amd/compiler/meson.build
@@ -78,6 +78,7 @@ libaco_files = files(
   'aco_scheduler.cpp',
   'aco_ssa_elimination.cpp',
   'aco_spill.cpp',
+  'aco_util.h',
   'aco_validate.cpp',
 )
 


### PR DESCRIPTION
Introduce a span object to abstract the pointer + length construct used for `aco::Instruction::operations` and `aco::Instruction::definitions`

This not only encapsulates the complexity but also enables the easy usage of modern features such as range based loops and algorithms

This is on top of #48 
