### PR TITLE
Modernize some parts to C++14

### DIFF
--- a/src/amd/compiler/aco_instruction_selection_setup.cpp
+++ b/src/amd/compiler/aco_instruction_selection_setup.cpp
@@ -76,7 +76,7 @@ struct isel_context {
    bool *divergent_vals;
    std::unique_ptr<Temp[]> allocated;
    std::unordered_map<unsigned, std::array<Temp,4>> allocated_vec;
-   uint16_t stage; /* Stage */
+   Stage stage; /* Stage */
    struct {
       bool has_branch;
       uint16_t loop_nest_depth = 0;

--- a/src/amd/compiler/aco_ir.h
+++ b/src/amd/compiler/aco_ir.h
@@ -997,46 +997,46 @@ struct Block {
    Block() : index(0) {}
 };
 
-typedef uint16_t Stage;
+using Stage = uint16_t;
 
 /* software stages */
-static const Stage sw_vs = 1 << 0;
-static const Stage sw_gs = 1 << 1;
-static const Stage sw_tcs = 1 << 2;
-static const Stage sw_tes = 1 << 3;
-static const Stage sw_fs = 1 << 4;
-static const Stage sw_cs = 1 << 5;
-static const Stage sw_mask = 0x3f;
+static constexpr Stage sw_vs = 1 << 0;
+static constexpr Stage sw_gs = 1 << 1;
+static constexpr Stage sw_tcs = 1 << 2;
+static constexpr Stage sw_tes = 1 << 3;
+static constexpr Stage sw_fs = 1 << 4;
+static constexpr Stage sw_cs = 1 << 5;
+static constexpr Stage sw_mask = 0x3f;
 
 /* hardware stages (can't be OR'd, just a mask for convenience when testing multiple) */
-static const Stage hw_vs = 1 << 6;
-static const Stage hw_es = 1 << 7;
-static const Stage hw_gs = 1 << 8; /* not on GFX9. combined into ES on GFX9 (and GFX10/legacy). */
-static const Stage hw_ls = 1 << 9;
-static const Stage hw_hs = 1 << 10; /* not on GFX9. combined into LS on GFX9 (and GFX10/legacy). */
-static const Stage hw_fs = 1 << 11;
-static const Stage hw_cs = 1 << 12;
-static const Stage hw_mask = 0x7f << 6;
+static constexpr Stage hw_vs = 1 << 6;
+static constexpr Stage hw_es = 1 << 7;
+static constexpr Stage hw_gs = 1 << 8; /* not on GFX9. combined into ES on GFX9 (and GFX10/legacy). */
+static constexpr Stage hw_ls = 1 << 9;
+static constexpr Stage hw_hs = 1 << 10; /* not on GFX9. combined into LS on GFX9 (and GFX10/legacy). */
+static constexpr Stage hw_fs = 1 << 11;
+static constexpr Stage hw_cs = 1 << 12;
+static constexpr Stage hw_mask = 0x7f << 6;
 
 /* possible settings of Program::stage */
-static const Stage vertex_vs = sw_vs | hw_vs;
-static const Stage fragment_fs = sw_fs | hw_fs;
-static const Stage compute_cs = sw_cs | hw_cs;
-static const Stage tess_eval_vs = sw_tes | hw_vs;
+static constexpr Stage vertex_vs = sw_vs | hw_vs;
+static constexpr Stage fragment_fs = sw_fs | hw_fs;
+static constexpr Stage compute_cs = sw_cs | hw_cs;
+static constexpr Stage tess_eval_vs = sw_tes | hw_vs;
 /* GFX10/NGG */
-static const Stage ngg_vertex_gs = sw_vs | hw_gs;
-static const Stage ngg_vertex_geometry_gs = sw_vs | sw_gs | hw_gs;
-static const Stage ngg_tess_eval_geometry_gs = sw_tes | sw_gs | hw_gs;
-static const Stage ngg_vertex_tess_control_hs = sw_vs | sw_tcs | hw_hs;
+static constexpr Stage ngg_vertex_gs = sw_vs | hw_gs;
+static constexpr Stage ngg_vertex_geometry_gs = sw_vs | sw_gs | hw_gs;
+static constexpr Stage ngg_tess_eval_geometry_gs = sw_tes | sw_gs | hw_gs;
+static constexpr Stage ngg_vertex_tess_control_hs = sw_vs | sw_tcs | hw_hs;
 /* GFX9 (and GFX10 if NGG isn't used) */
-static const Stage vertex_geometry_es = sw_vs | sw_gs | hw_es;
-static const Stage vertex_tess_control_ls = sw_vs | sw_tcs | hw_ls;
-static const Stage tess_eval_geometry_es = sw_tes | sw_gs | hw_es;
+static constexpr Stage vertex_geometry_es = sw_vs | sw_gs | hw_es;
+static constexpr Stage vertex_tess_control_ls = sw_vs | sw_tcs | hw_ls;
+static constexpr Stage tess_eval_geometry_es = sw_tes | sw_gs | hw_es;
 /* pre-GFX9 */
-static const Stage vertex_ls = sw_vs | hw_ls; /* vertex before tesselation control */
-static const Stage tess_control_hs = sw_tcs | hw_hs;
-static const Stage tess_eval_es = sw_tes | hw_gs; /* tesselation evaluation before GS */
-static const Stage geometry_gs = sw_gs | hw_gs;
+static constexpr Stage vertex_ls = sw_vs | hw_ls; /* vertex before tesselation control */
+static constexpr Stage tess_control_hs = sw_tcs | hw_hs;
+static constexpr Stage tess_eval_es = sw_tes | hw_gs; /* tesselation evaluation before GS */
+static constexpr Stage geometry_gs = sw_gs | hw_gs;
 
 class Program final {
 public:
@@ -1048,7 +1048,7 @@ public:
    struct radv_shader_info *info;
    enum chip_class chip_class;
    enum radeon_family family;
-   uint16_t stage; /* Stage */
+   Stage stage; /* Stage */
    bool needs_exact = false; /* there exists an instruction with disable_wqm = true */
    bool needs_wqm = false; /* there exists a p_wqm instruction */
    bool wb_smem_l1_on_end = false;

--- a/src/amd/compiler/aco_ir.h
+++ b/src/amd/compiler/aco_ir.h
@@ -909,47 +909,47 @@ enum block_kind {
 
 struct RegisterDemand {
    constexpr RegisterDemand() = default;
-   constexpr RegisterDemand(const int16_t v, const int16_t s)
+   constexpr RegisterDemand(const int16_t v, const int16_t s) noexcept
       : vgpr{v}, sgpr{s} {}
    int16_t vgpr = 0;
    int16_t sgpr = 0;
 
-   constexpr friend bool operator==(const RegisterDemand a, const RegisterDemand b) {
+   constexpr friend bool operator==(const RegisterDemand a, const RegisterDemand b) noexcept {
       return a.vgpr == b.vgpr && a.sgpr == b.sgpr;
    }
 
-   constexpr bool exceeds(const RegisterDemand other) const {
+   constexpr bool exceeds(const RegisterDemand other) const noexcept {
       return vgpr > other.vgpr || sgpr > other.sgpr;
    }
 
-   RegisterDemand operator+(const Temp t) const {
+   constexpr RegisterDemand operator+(const Temp t) const noexcept {
       if (t.type() == RegType::sgpr)
          return RegisterDemand( vgpr, sgpr + t.size() );
       else
          return RegisterDemand( vgpr + t.size(), sgpr );
    }
 
-   RegisterDemand operator+(const RegisterDemand other) const {
+   constexpr RegisterDemand operator+(const RegisterDemand other) const noexcept {
       return RegisterDemand(vgpr + other.vgpr, sgpr + other.sgpr);
    }
 
-   RegisterDemand operator-(const RegisterDemand other) const {
+   constexpr RegisterDemand operator-(const RegisterDemand other) const noexcept {
       return RegisterDemand(vgpr - other.vgpr, sgpr - other.sgpr);
    }
 
-   RegisterDemand& operator+=(const RegisterDemand other) {
+   constexpr RegisterDemand& operator+=(const RegisterDemand other) noexcept {
       vgpr += other.vgpr;
       sgpr += other.sgpr;
       return *this;
    }
 
-   RegisterDemand& operator-=(const RegisterDemand other) {
+   constexpr RegisterDemand& operator-=(const RegisterDemand other) noexcept {
       vgpr -= other.vgpr;
       sgpr -= other.sgpr;
       return *this;
    }
 
-   RegisterDemand& operator+=(const Temp t) {
+   constexpr RegisterDemand& operator+=(const Temp t) noexcept {
       if (t.type() == RegType::sgpr)
          sgpr += t.size();
       else
@@ -957,7 +957,7 @@ struct RegisterDemand {
       return *this;
    }
 
-   RegisterDemand& operator-=(const Temp t) {
+   constexpr RegisterDemand& operator-=(const Temp t) noexcept {
       if (t.type() == RegType::sgpr)
          sgpr -= t.size();
       else
@@ -965,7 +965,7 @@ struct RegisterDemand {
       return *this;
    }
 
-   void update(const RegisterDemand other) {
+   constexpr void update(const RegisterDemand other) noexcept {
       vgpr = std::max(vgpr, other.vgpr);
       sgpr = std::max(sgpr, other.sgpr);
    }

--- a/src/amd/compiler/aco_ir.h
+++ b/src/amd/compiler/aco_ir.h
@@ -102,7 +102,7 @@ enum barrier_interaction {
    barrier_count = 4,
 };
 
-static inline Format asVOP3(Format format) {
+constexpr Format asVOP3(Format format) {
    return (Format) ((uint32_t) Format::VOP3 | (uint32_t) format);
 };
 
@@ -853,7 +853,7 @@ T* create_instruction(aco_opcode opcode, Format format, uint32_t num_operands, u
    return inst;
 }
 
-static inline bool is_phi(Instruction* instr)
+constexpr bool is_phi(Instruction* instr)
 {
    return instr->opcode == aco_opcode::p_phi || instr->opcode == aco_opcode::p_linear_phi;
 }
@@ -863,7 +863,7 @@ static inline bool is_phi(aco_ptr<Instruction>& instr)
    return is_phi(instr.get());
 }
 
-static inline barrier_interaction get_barrier_interaction(Instruction* instr)
+constexpr barrier_interaction get_barrier_interaction(Instruction* instr)
 {
    switch (instr->format) {
    case Format::SMEM:

--- a/src/amd/compiler/aco_ir.h
+++ b/src/amd/compiler/aco_ir.h
@@ -464,68 +464,68 @@ public:
       setFixed(reg);
    }
 
-   bool isTemp() const noexcept
+   constexpr bool isTemp() const noexcept
    {
       return tempId() > 0;
    }
 
-   Temp getTemp() const noexcept
+   constexpr Temp getTemp() const noexcept
    {
       return temp;
    }
 
-   uint32_t tempId() const noexcept
+   constexpr uint32_t tempId() const noexcept
    {
       return temp.id();
    }
 
-   void setTemp(Temp t) {
+   constexpr void setTemp(Temp t) noexcept {
       temp = t;
    }
 
-   RegClass regClass() const noexcept
+   constexpr RegClass regClass() const noexcept
    {
       return temp.regClass();
    }
 
-   unsigned size() const noexcept
+   constexpr unsigned size() const noexcept
    {
       return temp.size();
    }
 
-   bool isFixed() const noexcept
+   constexpr bool isFixed() const noexcept
    {
       return isFixed_;
    }
 
-   PhysReg physReg() const noexcept
+   constexpr PhysReg physReg() const noexcept
    {
       return reg_;
    }
 
-   void setFixed(PhysReg reg) noexcept
+   constexpr void setFixed(PhysReg reg) noexcept
    {
       isFixed_ = 1;
       reg_ = reg;
    }
 
-   void setHint(PhysReg reg) noexcept
+   constexpr void setHint(PhysReg reg) noexcept
    {
       hasHint_ = 1;
       reg_ = reg;
    }
 
-   bool hasHint() const noexcept
+   constexpr bool hasHint() const noexcept
    {
       return hasHint_;
    }
 
-   void setKill(bool flag) noexcept
+   constexpr void setKill(bool flag) noexcept
    {
       isKill_ = flag;
    }
 
-   bool isKill() const noexcept
+   constexpr bool isKill() const noexcept
    {
       return isKill_;
    }

--- a/src/amd/compiler/aco_ir.h
+++ b/src/amd/compiler/aco_ir.h
@@ -205,7 +205,7 @@ private:
 struct PhysReg {
    PhysReg() = default;
    explicit constexpr PhysReg(unsigned r) : reg(r) {}
-   operator unsigned() const { return reg; }
+   constexpr operator unsigned() const { return reg; }
 
    uint16_t reg;
 };
@@ -311,38 +311,38 @@ public:
       setFixed(reg);
    }
 
-   bool isTemp() const noexcept
+   constexpr bool isTemp() const noexcept
    {
       return isTemp_;
    }
 
-   void setTemp(Temp t) {
+   constexpr void setTemp(Temp t) noexcept {
       assert(!isConstant_);
       isTemp_ = true;
       data_.temp = t;
    }
 
-   Temp getTemp() const noexcept
+   constexpr Temp getTemp() const noexcept
    {
       return data_.temp;
    }
 
-   uint32_t tempId() const noexcept
+   constexpr uint32_t tempId() const noexcept
    {
       return data_.temp.id();
    }
 
-   bool hasRegClass() const noexcept
+   constexpr bool hasRegClass() const noexcept
    {
       return isTemp() || isUndefined();
    }
 
-   RegClass regClass() const noexcept
+   constexpr RegClass regClass() const noexcept
    {
       return data_.temp.regClass();
    }
 
-   unsigned size() const noexcept
+   constexpr unsigned size() const noexcept
    {
       if (isConstant())
          return is64BitConst_ ? 2 : 1;
@@ -350,60 +350,60 @@ public:
          return data_.temp.size();
    }
 
-   bool isFixed() const noexcept
+   constexpr bool isFixed() const noexcept
    {
       return isFixed_;
    }
 
-   PhysReg physReg() const noexcept
+   constexpr PhysReg physReg() const noexcept
    {
       return reg_;
    }
 
-   void setFixed(PhysReg reg) noexcept
+   constexpr void setFixed(PhysReg reg) noexcept
    {
-      isFixed_ = reg != (unsigned)-1;
+      isFixed_ = reg != unsigned(-1);
       reg_ = reg;
    }
 
-   bool isConstant() const noexcept
+   constexpr bool isConstant() const noexcept
    {
       return isConstant_;
    }
 
-   bool isLiteral() const noexcept
+   constexpr bool isLiteral() const noexcept
    {
       return isConstant() && reg_ == 255;
    }
 
-   bool isUndefined() const noexcept
+   constexpr bool isUndefined() const noexcept
    {
       return isUndef_;
    }
 
-   uint32_t constantValue() const noexcept
+   constexpr uint32_t constantValue() const noexcept
    {
       return data_.i;
    }
 
-   bool constantEquals(uint32_t cmp) const noexcept
+   constexpr bool constantEquals(uint32_t cmp) const noexcept
    {
       return isConstant() && constantValue() == cmp;
    }
 
-   void setKill(bool flag) noexcept
+   constexpr void setKill(bool flag) noexcept
    {
       isKill_ = flag;
       if (!flag)
          setFirstKill(false);
    }
 
-   bool isKill() const noexcept
+   constexpr bool isKill() const noexcept
    {
       return isKill_ || isFirstKill();
    }
 
-   void setFirstKill(bool flag) noexcept
+   constexpr void setFirstKill(bool flag) noexcept
    {
       isFirstKill_ = flag;
       if (flag)
@@ -412,7 +412,7 @@ public:
 
    /* When there are multiple operands killing the same temporary,
     * isFirstKill() is only returns true for the first one. */
-   bool isFirstKill() const noexcept
+   constexpr bool isFirstKill() const noexcept
    {
       return isFirstKill_;
    }

--- a/src/amd/compiler/aco_ir.h
+++ b/src/amd/compiler/aco_ir.h
@@ -553,7 +553,7 @@ struct Instruction {
    aco::span<Operand> operands;
    aco::span<Definition> definitions;
 
-   bool isVALU()
+   constexpr bool isVALU() const noexcept
    {
       return ((uint16_t) format & (uint16_t) Format::VOP1) == (uint16_t) Format::VOP1
           || ((uint16_t) format & (uint16_t) Format::VOP2) == (uint16_t) Format::VOP2
@@ -562,7 +562,8 @@ struct Instruction {
           || ((uint16_t) format & (uint16_t) Format::VOP3B) == (uint16_t) Format::VOP3B
           || ((uint16_t) format & (uint16_t) Format::VOP3P) == (uint16_t) Format::VOP3P;
    }
-   bool isSALU()
+
+   constexpr bool isSALU() const noexcept
    {
       return format == Format::SOP1 ||
              format == Format::SOP2 ||
@@ -570,28 +571,32 @@ struct Instruction {
              format == Format::SOPK ||
              format == Format::SOPP;
    }
-   bool isVMEM()
+
+   constexpr bool isVMEM() const noexcept
    {
       return format == Format::MTBUF ||
              format == Format::MUBUF ||
              format == Format::MIMG;
    }
-   bool isDPP()
+
+   constexpr bool isDPP() const noexcept
    {
       return (uint16_t) format & (uint16_t) Format::DPP;
    }
-   bool isVOP3()
+
+   constexpr bool isVOP3() const noexcept
    {
       return ((uint16_t) format & (uint16_t) Format::VOP3A) ||
              ((uint16_t) format & (uint16_t) Format::VOP3B) ||
              format == Format::VOP3P;
    }
-   bool isSDWA()
+
+   constexpr bool isSDWA() const noexcept
    {
       return (uint16_t) format & (uint16_t) Format::SDWA;
    }
 
-   bool isFlatOrGlobal()
+   constexpr bool isFlatOrGlobal() const noexcept
    {
       return format == Format::FLAT || format == Format::GLOBAL;
    }

--- a/src/amd/compiler/aco_util.h
+++ b/src/amd/compiler/aco_util.h
@@ -64,84 +64,84 @@ public:
    /*! \brief                 Returns an iterator to the begin of the span
    *   \return                data
    */
-   iterator begin() noexcept {
+   constexpr iterator begin() noexcept {
       return data;
    }
 
    /*! \brief                 Returns a const_iterator to the begin of the span
    *   \return                data
    */
-   const_iterator begin() const noexcept {
+   constexpr const_iterator begin() const noexcept {
       return data;
    }
 
    /*! \brief                 Returns an iterator to the end of the span
    *   \return                data + length
    */
-   iterator end() noexcept {
+   constexpr iterator end() noexcept {
       return std::next(data, length);
    }
 
    /*! \brief                 Returns a const_iterator to the end of the span
    *   \return                data + length
    */
-   const_iterator end() const noexcept {
+   constexpr const_iterator end() const noexcept {
       return std::next(data, length);
    }
 
    /*! \brief                 Returns a const_iterator to the begin of the span
    *   \return                data
    */
-   const_iterator cbegin() const noexcept {
+   constexpr const_iterator cbegin() const noexcept {
       return data;
    }
 
    /*! \brief                 Returns a const_iterator to the end of the span
    *   \return                data + length
    */
-   const_iterator cend() const noexcept {
+   constexpr const_iterator cend() const noexcept {
       return std::next(data, length);
    }
 
    /*! \brief                 Returns a reverse_iterator to the end of the span
    *   \return                reverse_iterator(end())
    */
-   reverse_iterator rbegin() noexcept {
+   constexpr reverse_iterator rbegin() noexcept {
       return reverse_iterator(end());
    }
 
    /*! \brief                 Returns a const_reverse_iterator to the end of the span
    *   \return                reverse_iterator(end())
    */
-   const_reverse_iterator rbegin() const noexcept {
+   constexpr const_reverse_iterator rbegin() const noexcept {
       return const_reverse_iterator(end());
    }
 
    /*! \brief                 Returns a reverse_iterator to the begin of the span
    *   \return                reverse_iterator(begin())
    */
-   reverse_iterator rend() noexcept {
+   constexpr reverse_iterator rend() noexcept {
       return reverse_iterator(begin());
    }
 
    /*! \brief                 Returns a const_reverse_iterator to the begin of the span
    *   \return                reverse_iterator(begin())
    */
-   const_reverse_iterator rend() const noexcept {
+   constexpr const_reverse_iterator rend() const noexcept {
       return const_reverse_iterator(begin());
    }
 
    /*! \brief                 Returns a const_reverse_iterator to the end of the span
    *   \return                rbegin()
    */
-   const_reverse_iterator crbegin() const noexcept {
+   constexpr const_reverse_iterator crbegin() const noexcept {
       return const_reverse_iterator(cend());
    }
 
    /*! \brief                 Returns a const_reverse_iterator to the begin of the span
    *   \return                rend()
    */
-   const_reverse_iterator crend() const noexcept {
+   constexpr const_reverse_iterator crend() const noexcept {
       return const_reverse_iterator(cbegin());
    }
 
@@ -149,7 +149,7 @@ public:
    *   \param[in] index       Index of the element we want to access
    *   \return                *(std::next(data, index))
    */
-   reference operator[](const size_type index) noexcept {
+   constexpr reference operator[](const size_type index) noexcept {
       assert(length > index);
       return *(std::next(data, index));
    }
@@ -158,7 +158,7 @@ public:
    *   \param[in] index       Index of the element we want to access
    *   \return                *(std::next(data, index))
    */
-   const_reference operator[](const size_type index) const noexcept {
+   constexpr const_reference operator[](const size_type index) const noexcept {
       assert(length > index);
       return *(std::next(data, index));
    }
@@ -166,7 +166,7 @@ public:
    /*! \brief                 Returns a reference to the last element of the span
    *   \return                *(std::next(data, length - 1))
    */
-   reference back() noexcept {
+   constexpr reference back() noexcept {
       assert(length > 0);
       return *(std::next(data, length - 1));
    }
@@ -174,7 +174,7 @@ public:
    /*! \brief                 Returns a const_reference to the last element of the span
    *   \return                *(std::next(data, length - 1))
    */
-   const_reference back() const noexcept {
+   constexpr const_reference back() const noexcept {
       assert(length > 0);
       return *(std::next(data, length - 1));
    }
@@ -182,7 +182,7 @@ public:
    /*! \brief                 Returns a reference to the first element of the span
    *   \return                *begin()
    */
-   reference front() noexcept {
+   constexpr reference front() noexcept {
       assert(length > 0);
       return *begin();
    }
@@ -190,7 +190,7 @@ public:
    /*! \brief                 Returns a const_reference to the first element of the span
    *   \return                *cbegin()
    */
-   const_reference front() const noexcept {
+   constexpr const_reference front() const noexcept {
       assert(length > 0);
       return *cbegin();
    }
@@ -211,14 +211,14 @@ public:
 
    /*! \brief                 Decreases the size of the span by 1
    */
-   void pop_back() noexcept {
+   constexpr void pop_back() noexcept {
       assert(length > 0);
       --length;
    }
 
    /*! \brief                 Clears the span
    */
-   void clear() noexcept {
+   constexpr void clear() noexcept {
       data = nullptr;
       length = 0;
    }


### PR DESCRIPTION
Now that the default standard is C++14 we can actually use some more advanced constructs that were not possible in C++11.

There is one kind of vexing thing `RegClass` has no `constexpr` default constructor as there is not default value for `RC rc;`

Consequently all dependend constructors cannot be marked `constexpr` Could we just define a `none` value and use that. As far as I can tell the compiler would assign it anyway.

For some reasons I also had to set -std=c++14` explicitly in the meson file is that just my setup?